### PR TITLE
Warn on header mismatch

### DIFF
--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -74,7 +74,6 @@ test_that("read_resource() understands CSV dialect properties", {
   # One attribute of this df will be different: skip = 0 (since no header)
   # The default read_resource() sets this to: skip = 1
   # Since that is not a difference we want to test, we overwrite it
-  attr(example_dialect_df, 'spec')$skip <- 1
 
   expect_identical(example_df, example_dialect_df)
 })


### PR DESCRIPTION
Implements #8. This is achieved by setting the `col_names` _after_ instead of _during_ `read_delim()`. I'm not sure it is better than the previous implementation, which was already returning pretty good warning messages by `read_delim()`. A **comparison below**. The only situation that is improved is 4, which might be pretty rare.

@damianooldoni interested to hear your thoughts on this.

Note: currently fails test, because tibble attributes are different.

## 1. More columns in schema than data (add column `end`)

Before:
- gives parsing error about expected columns mismatch **good**
- inserts extra column `end` **good**
- gives parsing error about inserted column expecting datetime, which does not match actual data **good**

```R
> read_resource(package, "deployments")
Warning: 5 parsing failures.
row col   expected                       actual                           file
  1 NA  6 columns  5 columns                    'inst/extdata/deployments.csv'
  2 end date like  On "forêt" road.             'inst/extdata/deployments.csv'
  2 NA  6 columns  5 columns                    'inst/extdata/deployments.csv'
  3 end date like  Malfunction: no photos, data 'inst/extdata/deployments.csv'
  3 NA  6 columns  5 columns                    'inst/extdata/deployments.csv'

# A tibble: 3 x 6
  deployment_id longitude latitude start               end                 comments
  <chr>             <dbl>    <dbl> <dttm>              <dttm>              <chr>   
1 1                  4.62     50.8 2020-01-02 11:35:10 NA                  NA      
2 2                  4.64     50.8 2020-12-01 13:45:53 NA                  NA      
3 3                  4.65     50.8 2019-05-04 13:26:33 NA                  NA      
```

Now:
- only 5 columns in dataframe **not desirable**

```R
> read_resource(package, "deployments")
Warning: 2 parsing failures.
row      col   expected                       actual                           file
  2 comments date like  On "forêt" road.             'inst/extdata/deployments.csv'
  3 comments date like  Malfunction: no photos, data 'inst/extdata/deployments.csv'

# A tibble: 3 x 5
  deployment_id longitude latitude start               end                
  <chr>             <dbl>    <dbl> <dttm>              <dttm>             
1 1                  4.62     50.8 2020-01-02 11:35:10 NA                 
2 2                  4.64     50.8 2020-12-01 13:45:53 NA                 
3 3                  4.65     50.8 2019-05-04 13:26:33 NA                 
Warning messages:
1: Unnamed `col_types` should have the same length as `col_names`. Using smaller of the two. 
2: In read_resource(package, "deployments") :
  Mismatch between `schema$fields` and headers in file `inst/extdata/deployments.csv`:
schema (used):
  deployment_id, longitude, latitude, start, end, comments
headers (ignored):
  deployment_id, longitude, latitude, start, comments
```

## 2. Less columns in schema than data (remove column `start`)

Before:
- gives parsing error about expected columns mismatch **good**
- drops `start`, meaning start data is shifted to `comments`, drops comments data  **understandable**

```R
> read_resource(package, "deployments")
Warning: 3 parsing failures.
row col  expected    actual                           file
  1  -- 4 columns 5 columns 'inst/extdata/deployments.csv'
  2  -- 4 columns 5 columns 'inst/extdata/deployments.csv'
  3  -- 4 columns 5 columns 'inst/extdata/deployments.csv'

# A tibble: 3 x 4
  deployment_id longitude latitude comments                 
  <chr>             <dbl>    <dbl> <chr>                    
1 1                  4.62     50.8 2020-01-02T12:35:10+01:00
2 2                  4.64     50.8 2020-12-01T14:45:53+01:00
3 3                  4.65     50.8 2019-05-04T14:26:33+01:00
```

Now:

```R
> read_resource(package, "deployments")
Warning: 3 parsing failures.
row col  expected    actual                           file
  1  -- 4 columns 5 columns 'inst/extdata/deployments.csv'
  2  -- 4 columns 5 columns 'inst/extdata/deployments.csv'
  3  -- 4 columns 5 columns 'inst/extdata/deployments.csv'

# A tibble: 3 x 4
  deployment_id longitude latitude comments                 
  <chr>             <dbl>    <dbl> <chr>                    
1 1                  4.62     50.8 2020-01-02T12:35:10+01:00
2 2                  4.64     50.8 2020-12-01T14:45:53+01:00
3 3                  4.65     50.8 2019-05-04T14:26:33+01:00
Warning messages:
1: Unnamed `col_types` should have the same length as `col_names`. Using smaller of the two. 
2: In read_resource(package, "deployments") :
  Mismatch between `schema$fields` and headers in file `inst/extdata/deployments.csv`:
schema (used):
  deployment_id, longitude, latitude, comments
headers (ignored):
  deployment_id, longitude, latitude, start
```

## 3. Shifted columns in schema vs data (switch `start` with `comments`)

Before:
- gives parsing error about `start` column expecting datetime, which does not match actual data **good**

```R
> read_resource(package, "deployments")
Warning: 2 parsing failures.
row   col   expected                       actual                           file
  2 start date like  On "forêt" road.             'inst/extdata/deployments.csv'
  3 start date like  Malfunction: no photos, data 'inst/extdata/deployments.csv'

# A tibble: 3 x 5
  deployment_id longitude latitude comments                  start              
  <chr>             <dbl>    <dbl> <chr>                     <dttm>             
1 1                  4.62     50.8 2020-01-02T12:35:10+01:00 NA                 
2 2                  4.64     50.8 2020-12-01T14:45:53+01:00 NA                 
3 3                  4.65     50.8 2019-05-04T14:26:33+01:00 NA                 
```

Now:

```R
> read_resource(package, "deployments")
Warning: 2 parsing failures.
row      col   expected                       actual                           file
  2 comments date like  On "forêt" road.             'inst/extdata/deployments.csv'
  3 comments date like  Malfunction: no photos, data 'inst/extdata/deployments.csv'

# A tibble: 3 x 5
  deployment_id longitude latitude comments                  start              
  <chr>             <dbl>    <dbl> <chr>                     <dttm>             
1 1                  4.62     50.8 2020-01-02T12:35:10+01:00 NA                 
2 2                  4.64     50.8 2020-12-01T14:45:53+01:00 NA                 
3 3                  4.65     50.8 2019-05-04T14:26:33+01:00 NA                 
Warning message:
In read_resource(package, "deployments") :
  Mismatch between `schema$fields` and headers in file `inst/extdata/deployments.csv`:
schema (used):
  deployment_id, longitude, latitude, comments, start
headers (ignored):
  deployment_id, longitude, latitude, start, comments
```

## 4. Shift columns of same type (switch `latitude` with `longitude`)

Before:
- No warning **unfortunate**

```R
# A tibble: 3 x 5
  deployment_id latitude longitude start               comments                      
  <chr>            <dbl>     <dbl> <dttm>              <chr>                         
1 1                 4.62      50.8 2020-01-02 11:35:10  NA                           
2 2                 4.64      50.8 2020-12-01 13:45:53 "On \"forêt\" road."          
3 3                 4.65      50.8 2019-05-04 13:26:33 "Malfunction: no photos, data"
```

Now:

```R
# A tibble: 3 x 5
  deployment_id latitude longitude start               comments                      
  <chr>            <dbl>     <dbl> <dttm>              <chr>                         
1 1                 4.62      50.8 2020-01-02 11:35:10  NA                           
2 2                 4.64      50.8 2020-12-01 13:45:53 "On \"forêt\" road."          
3 3                 4.65      50.8 2019-05-04 13:26:33 "Malfunction: no photos, data"
Warning message:
In read_resource(package, "deployments") :
  Mismatch between `schema$fields` and headers in file `inst/extdata/deployments.csv`:
schema (used):
  deployment_id, latitude, longitude, start, comments
headers (ignored):
  deployment_id, longitude, latitude, start, comments
```