### PR TITLE
Use spatial: null not image: null

### DIFF
--- a/inst/extdata/v1/datapackage.json
+++ b/inst/extdata/v1/datapackage.json
@@ -8,9 +8,9 @@
       "title": "CC0 1.0"
     }
   ],
-  "image": null,
   "version": "1.0",
   "created": "2021-03-02T17:22:33Z",
+  "spatial": null,
   "temporal": {
     "start": "2020-01-01",
     "end": "2021-01-10"

--- a/inst/extdata/v2/datapackage.json
+++ b/inst/extdata/v2/datapackage.json
@@ -9,9 +9,9 @@
       "title": "CC0 1.0"
     }
   ],
-  "image": null,
   "version": "2.0",
   "created": "2024-08-27T12:45:21Z",
+  "spatial": null,
   "temporal": {
     "start": "2020-01-01",
     "end": "2021-01-10"

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -128,6 +128,6 @@ test_that("read_package() allows YAML descriptor", {
 test_that("read_package() converts JSON null to NULL", {
   p_path <- system.file("extdata", "v1", "datapackage.json", package = "frictionless")
   p <- read_package(p_path)
-  # { "image": null } is read as NULL (use chuck() to force error if missing)
-  expect_null(purrr::chuck(p, "image"))
+  # { "spatial": null } is read as NULL (use chuck() to force error if missing)
+  expect_null(purrr::chuck(p, "spatial"))
 })

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -375,7 +375,7 @@ test_that("write_package() writes NULL and NA as null", {
   p <- example_package()
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
 
-  # Set some properties to NULL and NA (p$image is already read as NULL)
+  # Set some properties to NULL and NA (p$spatial is already read as NULL)
   p$null_property <- NULL
   p$na_property <- NA
   p <- add_resource(p, "new", df, na_property = NA)
@@ -387,7 +387,7 @@ test_that("write_package() writes NULL and NA as null", {
   p_reread <- read_package(file.path(dir, "datapackage.json"))
 
   # Properties are written as NULL (use chuck() to force error if missing)
-  expect_null(purrr::chuck(p_reread, "image"))
+  expect_null(purrr::chuck(p_reread, "spatial"))
   expect_null(p_reread$null_property) # Write should remove this property
   expect_null(purrr::chuck(p_reread, "na_property"))
   expect_null(purrr::chuck(p_reread, "resources", 4, "na_property"))


### PR DESCRIPTION
`image` is a Data Package property that is expected to be a string. It's doesn't return a validation error in frictionless-py, but does in [dpkit](https://dpkit.dev/). It's best we use a custom property/ I choose `spatial`.