### PR TITLE
Show deprecation warning for Data Packages created with previous versions of frictionless

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,20 +8,18 @@
 
 ## Changes for developers
 
-* Internal frictionless properties are now _attributes_, to better separate them from public Data Package properties (#289). If you use these internal properties, then update:
+* Internal frictionless properties `package$directory` and `resource$read_from` are now _attributes_ `attr(package, "directory")` and `attr(resource, "data_location")`. This separates them better from public Data Package and Resource _properties_ (#289). Saved Data Package objects created with previous versions of frictionless will show a deprecation warning (#293). If you use these internal properties in your R package, then update them:
 
   ```R
+  # Before
   package$directory
-  r <- frictionless:::get_resource(package, "resource_name") # Internal function
-  r$read_from
-  ```
+  resource <- frictionless:::get_resource(package, "resource_name") # Internal function
+  resource$read_from
   
-  to:
-  
-  ```R
+  # After
   attr(package, "directory")
-  r <- frictionless:::resource(package, "resource_name") # Renamed!
-  attr(r, "data_location") # Renamed!
+  resource <- frictionless:::resource(package, "resource_name") # Function renamed!
+  attr(resource, "data_location") # Attribute renamed!
   ```
 
 * frictionless now relies on R >= 4.1.0 (because of an indirect `{vroom}` dependency) (#291) and uses base pipes (`|>` rather than `%>%`) (#292).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## For users
 
-* `read_resource()` now supports reading from remote zip files, thanks to support in {vroom} (1.3.0) (#291).
+* `read_resource()` now supports reading from remote zip files, thanks to support in `{vroom}` (1.3.0) (#291).
 * `resources()` is soft-deprecated, please use `resource_names()` instead (#282).
 * `get_schema()` is soft-deprecated, please use `schema()` instead (#282).
 
@@ -24,7 +24,7 @@
   attr(r, "data_location") # Renamed!
   ```
 
-* frictionless now relies on R >= 4.1.0 (because of an indirect {vroom} dependency) (#291) and uses base pipes (`|>` rather than `%>%`) (#292).
+* frictionless now relies on R >= 4.1.0 (because of an indirect `{vroom}` dependency) (#291) and uses base pipes (`|>` rather than `%>%`) (#292).
 
 # frictionless 1.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## Changes for developers
 
-* Internal frictionless properties `package$directory` and `resource$read_from` are now _attributes_ `attr(package, "directory")` and `attr(resource, "data_location")`. This separates them better from public Data Package and Resource _properties_ (#289). Saved Data Package objects created with previous versions of frictionless will show a deprecation warning (#293). If you use these internal properties in your R package, then update them:
+* Internal frictionless properties `package$directory` and `resource$read_from` are now _attributes_ `attr(package, "directory")` and `attr(resource, "data_location")`. This separates them better from public Data Package and Resource _properties_ (#289). Saved Data Package objects created with previous versions of frictionless will show a deprecation warning (#293) and can be updated with `create_package()`. If you use these internal properties in your R package, then change them:
 
   ```R
   # Before
@@ -18,8 +18,8 @@
   
   # After
   attr(package, "directory")
-  resource <- frictionless:::resource(package, "resource_name") # Function renamed!
-  attr(resource, "data_location") # Attribute renamed!
+  resource <- frictionless:::resource(package, "resource_name") # Function renamed
+  attr(resource, "data_location") # Attribute renamed
   ```
 
 * frictionless now relies on R >= 4.1.0 (because of an indirect `{vroom}` dependency) (#291) and uses base pipes (`|>` rather than `%>%`) (#292).

--- a/R/check_package.R
+++ b/R/check_package.R
@@ -53,6 +53,18 @@ check_package <- function(package) {
     )
   }
 
+  # Handle deprecated package$directory property
+  if (is.character(package$directory)) {
+    lifecycle::deprecate_warn(
+      when = "1.3.0",
+      what = I("`package$directory`"),
+      details = "This Data Package was created with an older version of
+                 frictionless. Read or create it again to avoid this warning."
+    )
+    attr(package, "directory") <- package$directory
+    package$directory <- NULL
+  }
+
   # Check package has directory attribute (character)
   if (!is.character(attr(package, "directory"))) {
     cli::cli_abort(

--- a/R/check_package.R
+++ b/R/check_package.R
@@ -53,20 +53,17 @@ check_package <- function(package) {
     )
   }
 
-  # Handle deprecated package$directory property
+  # Check package has directory attribute (or deprecated package$directory)
   if (is.character(package$directory)) {
     lifecycle::deprecate_warn(
       when = "1.3.0",
       what = I("`package$directory`"),
-      details = "This Data Package was created with an older version of
-                 frictionless. Read or create it again to avoid this warning."
+      details = cli::format_inline(
+        "This Data Package object was created with an older version of
+           frictionless. Update it with {.fun create_package}."
+      )
     )
-    attr(package, "directory") <- package$directory
-    package$directory <- NULL
-  }
-
-  # Check package has directory attribute (character)
-  if (!is.character(attr(package, "directory"))) {
+  } else if (!is.character(attr(package, "directory"))) {
     cli::cli_abort(
       c(
         general_message,

--- a/R/create_package.R
+++ b/R/create_package.R
@@ -39,8 +39,12 @@ create_package <- function(descriptor = NULL) {
   # Add resources property (also creates descriptor if NULL)
   descriptor$resources <- descriptor$resources %||% list()
 
-  # Add directory attribute
+  # Add directory attribute (and remove deprecated package$directory)
   attr(descriptor, "directory") <- attr(descriptor, "directory") %||% "."
+  if (is.character(descriptor$directory)) {
+    attr(descriptor, "directory") <- descriptor$directory
+    descriptor$directory <- NULL
+  }
 
   # Add datapackage class
   if (!"datapackage" %in% class(descriptor)) {

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -11,9 +11,9 @@
 #' @name deprecated
 get_schema <- function(package, resource_name) {
   lifecycle::deprecate_soft(
-    "1.3.0",
-    "get_schema()",
-    "schema()"
+    when = "1.3.0",
+    what = "get_schema()",
+    with = "schema()"
   )
   schema(package, resource_name)
 }
@@ -27,9 +27,9 @@ get_schema <- function(package, resource_name) {
 #' @name deprecated
 resources <- function(package) {
   lifecycle::deprecate_soft(
-    "1.3.0",
-    "resources()",
-    "resource_names()"
+    when = "1.3.0",
+    what = "resources()",
+    with = "resource_names()"
   )
   resource_names(package)
 }

--- a/R/print.datapackage.R
+++ b/R/print.datapackage.R
@@ -19,7 +19,7 @@ print.datapackage <- function(x, ...) {
   # All prints should use cat (= cli::cat() helpers)
 
   # List resources
-  resource_names <- resource_names(x)
+  resource_names <- resource_names(x) # Calls check_package()
   cli::cat_line(
     cli::format_inline(
       "A Data Package with {length(resource_names)} resource{?s}{?./:/:}"

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -37,35 +37,40 @@ test_that("check_package() returns error if package is not a list", {
 })
 
 test_that("check_package() returns error on missing or incorrect resources", {
+  p_invalid <- create_package()
+  p_invalid$resources <- NULL
   expect_error(
-    check_package(list()),
+    check_package(p_invalid),
     class = "frictionless_error_package_invalid"
   )
+  p_invalid$resources <- "not_a_list"
   expect_error(
-    check_package(list(resources = "not_a_list")),
+    check_package(p_invalid),
     regexp = "`package` is missing a resources property or it is not a list.",
     fixed = TRUE
   )
   expect_error(
-    check_package(list(resources = "not_a_list")),
+    check_package(p_invalid),
     class = "frictionless_error_package_invalid"
   )
 })
 
 test_that("check_package() returns error on missing or incorrect directory", {
+  p_invalid <- create_package()
+  attr(p_invalid, "directory") <- NULL
   expect_error(
-    check_package(list(resources = list())),
+    check_package(p_invalid),
     class = "frictionless_error_package_invalid"
   )
   expect_error(
-    check_package(list(resources = list())),
+    check_package(p_invalid),
     regexp = paste(
       "`package` is missing a directory attribute or it is not a character."
     ),
     fixed = TRUE
   )
   expect_error(
-    check_package(list(resources = list(), directory = 5)),
+    check_package(p_invalid),
     class = "frictionless_error_package_invalid"
   )
 })
@@ -80,19 +85,20 @@ test_that("check_package() returns deprecation warning for package$directory", {
 })
 
 test_that("check_package() returns error if resources have no name", {
-  p <- example_package()
-  p$resources[[2]]$name <- NULL
+  p_invalid <- example_package()
+  p_invalid$resources[[2]]$name <- NULL
   expect_error(
-    check_package(p),
+    check_package(p_invalid),
     class = "frictionless_error_resources_without_name"
   )
   expect_error(
-    check_package(p),
+    check_package(p_invalid),
     regexp = "All resources in `package` must have a name property.",
     fixed = TRUE
   )
 
   # Expect no error on empty resources
+  p <- example_package()
   p$resources <- list()
   expect_no_error(check_package(p))
 })

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -70,6 +70,15 @@ test_that("check_package() returns error on missing or incorrect directory", {
   )
 })
 
+test_that("check_package() returns deprecation warning for package$directory", {
+  p_directory_prop <- example_package()
+  p_directory_prop$directory <- attr(p_directory_prop, "directory")
+  attr(p_directory_prop, "directory") <- NULL
+
+  lifecycle::expect_deprecated(check_package(p_directory_prop))
+  expect_no_error(suppressWarnings(check_package(p_directory_prop)))
+})
+
 test_that("check_package() returns error if resources have no name", {
   p <- example_package()
   p$resources[[2]]$name <- NULL

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -76,12 +76,12 @@ test_that("check_package() returns error on missing or incorrect directory", {
 })
 
 test_that("check_package() returns deprecation warning for package$directory", {
-  p_directory_prop <- example_package()
-  p_directory_prop$directory <- attr(p_directory_prop, "directory")
-  attr(p_directory_prop, "directory") <- NULL
+  p_directory <- example_package()
+  p_directory$directory <- attr(p_directory, "directory")
+  attr(p_directory, "directory") <- NULL
 
-  lifecycle::expect_deprecated(check_package(p_directory_prop))
-  expect_no_error(suppressWarnings(check_package(p_directory_prop)))
+  lifecycle::expect_deprecated(check_package(p_directory))
+  expect_no_error(suppressWarnings(check_package(p_directory)))
 })
 
 test_that("check_package() returns error if resources have no name", {

--- a/tests/testthat/test-create_package.R
+++ b/tests/testthat/test-create_package.R
@@ -43,6 +43,16 @@ test_that("create_package() sets directory or leaves as is", {
   expect_identical(attr(existing, "directory"), "not_default")
 })
 
+test_that("create_package() updates deprecated package$directory", {
+  p_directory <- example_package()
+  p_directory$directory <- "not_default"
+  attr(p_directory, "directory") <- NULL
+  p_updated <- create_package(p_directory)
+
+  expect_null(p_updated$directory)
+  expect_identical(attr(p_updated, "directory"), "not_default")
+})
+
 test_that("create_package() adds class 'datapackage'", {
   new <- create_package()
   expect_s3_class(new, "datapackage")


### PR DESCRIPTION
Fix #293.

@sannegovaert this should resolve issues you had with `river_telemetry` and `o_assen` while frictionless 1.2.1.9000 was loaded.

You can test with:

```R
library(frictonless) # Installed from this branch
movepub::o_assen # Should show deprecation warning
movepub::o_assen # Should just show print, since warning is only shown once
```