### PR TITLE
Clarify `delim` parameter in `add_resource()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -25,10 +25,10 @@
 #'   If not provided, one will be created using [create_schema()].
 #' @param replace If `TRUE`, the added resource will replace an existing
 #'   resource with the same name.
-#' @param delim Single character used to separate the fields in the CSV file(s),
+#' @param delim Single character used to separate the fields in the source CSV file(s) to be read,
 #'   e.g. `\t` for tab delimited file.
 #'   Will be set as `delimiter` in the resource Table Dialect, so read functions
-#'.  know how to read the file(s).
+#'.  know how to read the file(s). When writing files with [write_package()] files always use a comma as the delimiting character (CSV).
 #' @param ... Additional [metadata properties](
 #'   https://docs.ropensci.org/frictionless/articles/data-resource.html#properties-implementation)
 #'   to add to the resource, e.g. `title = "My title", validated = FALSE`.

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -25,11 +25,11 @@
 #'   If not provided, one will be created using [create_schema()].
 #' @param replace If `TRUE`, the added resource will replace an existing
 #'   resource with the same name.
-#' @param delim Single character used to separate the fields in the source CSV 
-#'   file(s) to be read, e.g. `\t` for tab delimited file.
+#' @param delim Delimiter for the CSV file(s) referenced in `data` (e.g. `\t`
+#'   for a tab-separated file).
 #'   Will be set as `delimiter` in the resource Table Dialect, so read functions
-#'.  know how to read the file(s). When writing files with [write_package()] 
-#'   files always use a comma as the delimiting character (CSV).
+#'   know how to read the file(s).
+#'   Ignored if `data` is a data frame.
 #' @param ... Additional [metadata properties](
 #'   https://docs.ropensci.org/frictionless/articles/data-resource.html#properties-implementation)
 #'   to add to the resource, e.g. `title = "My title", validated = FALSE`.

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -25,10 +25,11 @@
 #'   If not provided, one will be created using [create_schema()].
 #' @param replace If `TRUE`, the added resource will replace an existing
 #'   resource with the same name.
-#' @param delim Single character used to separate the fields in the source CSV file(s) to be read,
-#'   e.g. `\t` for tab delimited file.
+#' @param delim Single character used to separate the fields in the source CSV 
+#'   file(s) to be read, e.g. `\t` for tab delimited file.
 #'   Will be set as `delimiter` in the resource Table Dialect, so read functions
-#'.  know how to read the file(s). When writing files with [write_package()] files always use a comma as the delimiting character (CSV).
+#'.  know how to read the file(s). When writing files with [write_package()] 
+#'   files always use a comma as the delimiting character (CSV).
 #' @param ... Additional [metadata properties](
 #'   https://docs.ropensci.org/frictionless/articles/data-resource.html#properties-implementation)
 #'   to add to the resource, e.g. `title = "My title", validated = FALSE`.

--- a/man/add_resource.Rd
+++ b/man/add_resource.Rd
@@ -39,10 +39,11 @@ If not provided, one will be created using \code{\link[=create_schema]{create_sc
 \item{replace}{If \code{TRUE}, the added resource will replace an existing
 resource with the same name.}
 
-\item{delim}{Single character used to separate the fields in the CSV file(s),
-e.g. \verb{\\t} for tab delimited file.
+\item{delim}{Single character used to separate the fields in the source CSV
+file(s) to be read, e.g. \verb{\\t} for tab delimited file.
 Will be set as \code{delimiter} in the resource Table Dialect, so read functions
-.  know how to read the file(s).}
+.  know how to read the file(s). When writing files with \code{\link[=write_package]{write_package()}}
+files always use a comma as the delimiting character (CSV).}
 
 \item{...}{Additional \href{https://docs.ropensci.org/frictionless/articles/data-resource.html#properties-implementation}{metadata properties}
 to add to the resource, e.g. \verb{title = "My title", validated = FALSE}.
@@ -113,7 +114,7 @@ package <- add_resource(
 resource_names(package)
 }
 \seealso{
-Other edit functions: 
-\code{\link{remove_resource}()}
+Other edit functions:
+\code{\link[=remove_resource]{remove_resource()}}
 }
 \concept{edit functions}

--- a/man/add_resource.Rd
+++ b/man/add_resource.Rd
@@ -39,11 +39,11 @@ If not provided, one will be created using \code{\link[=create_schema]{create_sc
 \item{replace}{If \code{TRUE}, the added resource will replace an existing
 resource with the same name.}
 
-\item{delim}{Single character used to separate the fields in the source CSV
-file(s) to be read, e.g. \verb{\\t} for tab delimited file.
+\item{delim}{Delimiter for the CSV file(s) referenced in \code{data} (e.g. \verb{\\t}
+for a tab-separated file).
 Will be set as \code{delimiter} in the resource Table Dialect, so read functions
-.  know how to read the file(s). When writing files with \code{\link[=write_package]{write_package()}}
-files always use a comma as the delimiting character (CSV).}
+know how to read the file(s).
+Ignored if \code{data} is a data frame.}
 
 \item{...}{Additional \href{https://docs.ropensci.org/frictionless/articles/data-resource.html#properties-implementation}{metadata properties}
 to add to the resource, e.g. \verb{title = "My title", validated = FALSE}.

--- a/man/create_package.Rd
+++ b/man/create_package.Rd
@@ -42,7 +42,7 @@ package
 str(package)
 }
 \seealso{
-Other create functions: 
-\code{\link{create_schema}()}
+Other create functions:
+\code{\link[=create_schema]{create_schema()}}
 }
 \concept{create functions}

--- a/man/create_schema.Rd
+++ b/man/create_schema.Rd
@@ -36,7 +36,7 @@ schema <- create_schema(df)
 str(schema)
 }
 \seealso{
-Other create functions: 
-\code{\link{create_package}()}
+Other create functions:
+\code{\link[=create_package]{create_package()}}
 }
 \concept{create functions}

--- a/man/frictionless-package.Rd
+++ b/man/frictionless-package.Rd
@@ -18,18 +18,19 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Peter Desmet \email{peter.desmet@inbo.be} (\href{https://orcid.org/0000-0002-8442-8025}{ORCID}) (Research Institute for Nature and Forest (INBO))
+\strong{Maintainer}: Peter Desmet \email{peter.desmet@inbo.be} (\href{https://orcid.org/0000-0002-8442-8025}{ORCID}) (affiliation: Research Institute for Nature and Forest (INBO))
 
 Authors:
 \itemize{
-  \item Damiano Oldoni \email{damiano.oldoni@inbo.be} (\href{https://orcid.org/0000-0003-3445-7562}{ORCID}) (Research Institute for Nature and Forest (INBO))
-  \item Pieter Huybrechts \email{pieter.huybrechts@inbo.be} (\href{https://orcid.org/0000-0002-6658-6062}{ORCID}) (Research Institute for Nature and Forest (INBO))
-  \item Sanne Govaert \email{sanne.govaert@inbo.be} (\href{https://orcid.org/0000-0002-8939-1305}{ORCID}) (Research Institute for Nature and Forest (INBO))
+  \item Peter Desmet \email{peter.desmet@inbo.be} (\href{https://orcid.org/0000-0002-8442-8025}{ORCID}) (affiliation: Research Institute for Nature and Forest (INBO))
+  \item Damiano Oldoni \email{damiano.oldoni@inbo.be} (\href{https://orcid.org/0000-0003-3445-7562}{ORCID}) (affiliation: Research Institute for Nature and Forest (INBO))
+  \item Pieter Huybrechts \email{pieter.huybrechts@inbo.be} (\href{https://orcid.org/0000-0002-6658-6062}{ORCID}) (affiliation: Research Institute for Nature and Forest (INBO))
+  \item Sanne Govaert \email{sanne.govaert@inbo.be} (\href{https://orcid.org/0000-0002-8939-1305}{ORCID}) (affiliation: Research Institute for Nature and Forest (INBO))
 }
 
 Other contributors:
 \itemize{
-  \item Kyle Husmann \email{kdh38@psu.edu} (\href{https://orcid.org/0000-0001-9875-8976}{ORCID}) (Pennsylvania State University) [contributor]
+  \item Kyle Husmann \email{kdh38@psu.edu} (\href{https://orcid.org/0000-0001-9875-8976}{ORCID}) (affiliation: Pennsylvania State University) [contributor]
   \item Research Institute for Nature and Forest (INBO) (\href{https://ror.org/00j54wy13}{ROR}) [copyright holder]
   \item Research Foundation - Flanders (https://lifewatch.be) [funder]
   \item Beatriz Milz \email{milz.bea@gmail.com} (\href{https://orcid.org/0000-0002-3064-4486}{ORCID}) [reviewer]

--- a/man/read_package.Rd
+++ b/man/read_package.Rd
@@ -33,7 +33,7 @@ package$name
 package$created
 }
 \seealso{
-Other read functions: 
-\code{\link{read_resource}()}
+Other read functions:
+\code{\link[=read_resource]{read_resource()}}
 }
 \concept{read functions}

--- a/man/read_resource.Rd
+++ b/man/read_resource.Rd
@@ -58,7 +58,7 @@ purrr::map_chr(package$resources[[2]]$schema$fields, "type")
 read_resource(package, "deployments", col_select = c("latitude", "longitude"))
 }
 \seealso{
-Other read functions: 
-\code{\link{read_package}()}
+Other read functions:
+\code{\link[=read_package]{read_package()}}
 }
 \concept{read functions}

--- a/man/remove_resource.Rd
+++ b/man/remove_resource.Rd
@@ -33,7 +33,7 @@ package <- remove_resource(package, "observations")
 resource_names(package)
 }
 \seealso{
-Other edit functions: 
-\code{\link{add_resource}()}
+Other edit functions:
+\code{\link[=add_resource]{add_resource()}}
 }
 \concept{edit functions}

--- a/man/resource_names.Rd
+++ b/man/resource_names.Rd
@@ -24,7 +24,7 @@ package <- example_package()
 resource_names(package)
 }
 \seealso{
-Other accessor functions: 
-\code{\link{schema}()}
+Other accessor functions:
+\code{\link[=schema]{schema()}}
 }
 \concept{accessor functions}

--- a/man/schema.Rd
+++ b/man/schema.Rd
@@ -33,7 +33,7 @@ schema <- schema(package, "observations")
 str(schema)
 }
 \seealso{
-Other accessor functions: 
-\code{\link{resource_names}()}
+Other accessor functions:
+\code{\link[=resource_names]{resource_names()}}
 }
 \concept{accessor functions}

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -31,7 +31,7 @@ location of file(s).
 \item Resource \code{path} has only URL(s): resource stays as is.
 \item Resource has inline \code{data} originally: resource stays as is.
 \item Resource has inline \code{data} as result of adding data with \code{\link[=add_resource]{add_resource()}}:
-data are written to a CSV file using \code{\link[readr:write_delim]{readr::write_csv()}}, \code{path} points to
+data are written to a CSV file using \code{\link[readr:write_csv]{readr::write_csv()}}, \code{path} points to
 location of file, \code{data} property is removed.
 Use \code{compress = TRUE} to gzip those CSV files.
 }


### PR DESCRIPTION
Fix https://github.com/frictionlessdata/frictionless-r/issues/204

I've attempted to clarify the `delim` behavior in `add_resource()`, especially that it doesn't affect `write_package()`. When calling `devtools::document()` I updated a bunch of other function documentation. So I suppose that needed doing anyway! 

Please feel free to change my wording! 

We could also refer to a details section, and go into details there. 