### PR TITLE
Include version in print

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,9 @@
 
 ## For users
 
-* New `version()` determines what version of the Data Package standard is used by a Data Package (e.g. `"1.0"`, `"2.0"`, `">=2.0"`). This is based on the presence and value of the `$schema` property (#299).
+* New `version()` determines what version of the Data Package standard is used by a Data Package (e.g. `"1.0"`, `"2.0"`, `">=2.0"`), based on the presence and value of the `$schema` property (#299). This information is also returned by `print()` (#302).
 * `read_resource()` now supports reading from remote zip files, thanks to support in `{vroom}` (1.3.0) (#291).
-* `write_package()` will now print multiple `resource$path` and `resource$schema$missingValues` on multiple lines in the `datapackage.json` (#297).
+* `write_package()` will now print multiple `resource$path`, `resource$schema$missingValues`, `field$constraints$enum` on multiple lines in the `datapackage.json` (#297).
 * `add_resource()` with `replace = TRUE` will add the resource if there is none to replace, rather than throwing an error (#273).
 * `resources()` is soft-deprecated, please use `resource_names()` instead (#282).
 * `get_schema()` is soft-deprecated, please use `schema()` instead (#282).

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * New `version()` determines what version of the Data Package standard is used by a Data Package (e.g. `"1.0"`, `"2.0"`, `">=2.0"`), based on the presence and value of the `$schema` property (#299). This information is also returned by `print()` (#302).
 * `read_resource()` now supports reading from remote zip files, thanks to support in `{vroom}` (1.3.0) (#291).
-* `write_package()` will now print multiple `resource$path`, `resource$schema$missingValues`, `field$constraints$enum` on multiple lines in the `datapackage.json` (#297).
+* `write_package()` will now print multiple `resource$path`, `resource$schema$missingValues` and `field$constraints$enum` on multiple lines in the `datapackage.json` (#297).
 * `add_resource()` with `replace = TRUE` will add the resource if there is none to replace, rather than throwing an error (#273).
 * `resources()` is soft-deprecated, please use `resource_names()` instead (#282).
 * `get_schema()` is soft-deprecated, please use `schema()` instead (#282).

--- a/R/print.datapackage.R
+++ b/R/print.datapackage.R
@@ -18,13 +18,16 @@
 print.datapackage <- function(x, ...) {
   # All prints should use cat (= cli::cat() helpers)
 
-  # List resources
+  # Intro sentence
+  version <- version(x)
   resource_names <- resource_names(x) # Calls check_package()
   cli::cat_line(
     cli::format_inline(
-      "A Data Package with {length(resource_names)} resource{?s}{?./:/:}"
+      "A Data Package (version {.field {version}}) with {length(resource_names)} resource{?s}{?./:/:}" # nolint
     )
   )
+
+  # List resources
   if (length(resource_names) > 0) {
     cli::cat_bullet(resource_names, bullet = "bullet")
   }

--- a/tests/testthat/test-print.datapackage.R
+++ b/tests/testthat/test-print.datapackage.R
@@ -3,15 +3,31 @@ test_that("print.datapackage() returns output invisibly", {
   expect_false(output$visible)
 })
 
-test_that("print.datapackage() informs about the resources and unclass()", {
+test_that("print.datapackage() informs about the version, resources and
+           unclass()", {
   unclass_message <- "Use `unclass()` to print the Data Package as a list."
 
-  # 3 resources (example package)
-  p <- example_package()
+  # Version 1.0 with 3 resources
+  p <- example_package(version = "1.0")
   expect_output(
     print(p),
     regexp = paste(
-      "A Data Package with 3 resources:",
+      "A Data Package (version 1.0) with 3 resources:",
+      "* deployments",
+      "* observations",
+      "* media",
+      unclass_message,
+      sep = "\n"
+    ),
+    fixed = TRUE
+  )
+
+  # Version 2.0 with 3 resources
+  p <- example_package(version = "2.0")
+  expect_output(
+    print(p),
+    regexp = paste(
+      "A Data Package (version 2.0) with 3 resources:",
       "* deployments",
       "* observations",
       "* media",
@@ -28,7 +44,7 @@ test_that("print.datapackage() informs about the resources and unclass()", {
   expect_output(
     print(p1),
     regexp = paste(
-      "A Data Package with 1 resource:",
+      "A Data Package (version 1.0) with 1 resource:",
       "* new",
       unclass_message,
       sep = "\n"
@@ -41,7 +57,7 @@ test_that("print.datapackage() informs about the resources and unclass()", {
   expect_output(
     print(p0),
     regexp = paste(
-      "A Data Package with 0 resources.",
+      "A Data Package (version 1.0) with 0 resources.",
       unclass_message,
       sep = "\n"
     ),
@@ -58,7 +74,7 @@ test_that("print.datapackage() informs about information in package$id", {
   expect_output(
     print(p),
     regexp = paste(
-      "A Data Package with 0 resources.",
+      "A Data Package (version 1.0) with 0 resources.",
       "For more information, see <https://example.com>.",
       unclass_message,
       sep = "\n"
@@ -71,7 +87,7 @@ test_that("print.datapackage() informs about information in package$id", {
   expect_output(
     print(p),
     regexp = paste(
-      "A Data Package with 0 resources.",
+      "A Data Package (version 1.0) with 0 resources.",
       unclass_message,
       sep = "\n"
     ),

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -35,7 +35,7 @@ package <- read_package("https://zenodo.org/records/10053702/files/datapackage.j
 
 ``` r
 package
-#> A Data Package with 3 resources:
+#> A Data Package (version 1.0) with 3 resources:
 #> • reference-data
 #> • gps
 #> • acceleration
@@ -48,7 +48,7 @@ Since a Data Package is a list, you can pass it to functions that work on lists,
 
 ``` r
 str(package, list.len = 3)
-#> List of 4
+#> List of 3
 #>  $ id       : chr "https://doi.org/10.5281/zenodo.10053702"
 #>  $ profile  : chr "tabular-data-package"
 #>  $ resources:List of 3
@@ -59,15 +59,21 @@ str(package, list.len = 3)
 #>   .. .. [list output truncated]
 #>   ..$ :List of 7
 #>   .. ..$ name     : chr "gps"
-#>   .. ..$ path     : chr [1:3] "O_WESTERSCHELDE-gps-2018.csv.gz" "O_WESTERSCHELDE-gps-2019.csv.gz" "O_WESTERSCHELDE-gps-2020.csv.gz"
+#>   .. ..$ path     :List of 3
+#>   .. .. ..$ : chr "O_WESTERSCHELDE-gps-2018.csv.gz"
+#>   .. .. ..$ : chr "O_WESTERSCHELDE-gps-2019.csv.gz"
+#>   .. .. ..$ : chr "O_WESTERSCHELDE-gps-2020.csv.gz"
 #>   .. ..$ profile  : chr "tabular-data-resource"
 #>   .. .. [list output truncated]
 #>   ..$ :List of 7
 #>   .. ..$ name     : chr "acceleration"
-#>   .. ..$ path     : chr [1:3] "O_WESTERSCHELDE-acceleration-2018.csv.gz" "O_WESTERSCHELDE-acceleration-2019.csv.gz" "O_WESTERSCHELDE-acceleration-2020.csv.gz"
+#>   .. ..$ path     :List of 3
+#>   .. .. ..$ : chr "O_WESTERSCHELDE-acceleration-2018.csv.gz"
+#>   .. .. ..$ : chr "O_WESTERSCHELDE-acceleration-2019.csv.gz"
+#>   .. .. ..$ : chr "O_WESTERSCHELDE-acceleration-2020.csv.gz"
 #>   .. ..$ profile  : chr "tabular-data-resource"
 #>   .. .. [list output truncated]
-#>   [list output truncated]
+#>  - attr(*, "directory")= chr "https://zenodo.org/records/10053702/files"
 #>  - attr(*, "class")= chr [1:2] "datapackage" "list"
 ```
 
@@ -118,7 +124,7 @@ local_package <- read_package(
 )
 
 local_package
-#> A Data Package with 3 resources:
+#> A Data Package (version 1.0) with 3 resources:
 #> • deployments
 #> • observations
 #> • media
@@ -179,7 +185,7 @@ You can chain most frictionless functions together using pipes (`|>`), which imp
 
 ``` r
 my_package
-#> A Data Package with 1 resource:
+#> A Data Package (version 1.0) with 1 resource:
 #> • iris
 #> Use `unclass()` to print the Data Package as a list.
 ```
@@ -211,7 +217,10 @@ str(iris_schema)
 #>   .. ..$ name       : chr "Species"
 #>   .. ..$ type       : chr "string"
 #>   .. ..$ constraints:List of 1
-#>   .. .. ..$ enum: chr [1:3] "setosa" "versicolor" "virginica"
+#>   .. .. ..$ enum:List of 3
+#>   .. .. .. ..$ : chr "setosa"
+#>   .. .. .. ..$ : chr "versicolor"
+#>   .. .. .. ..$ : chr "virginica"
 ```
 
 You can also create a schema from a data frame, using `create_schema()`:
@@ -239,7 +248,10 @@ str(iris_schema)
 #>   .. ..$ name       : chr "Species"
 #>   .. ..$ type       : chr "string"
 #>   .. ..$ constraints:List of 1
-#>   .. .. ..$ enum: chr [1:3] "setosa" "versicolor" "virginica"
+#>   .. .. ..$ enum:List of 3
+#>   .. .. .. ..$ : chr "setosa"
+#>   .. .. .. ..$ : chr "versicolor"
+#>   .. .. .. ..$ : chr "virginica"
 ```
 
 Doing so allows you to customize the schema before adding the resource. E.g. let's add a description for `Sepal.Length`:
@@ -298,7 +310,10 @@ str(iris_schema)
 #>   .. ..$ name       : chr "Species"
 #>   .. ..$ type       : chr "string"
 #>   .. ..$ constraints:List of 1
-#>   .. .. ..$ enum: chr [1:3] "setosa" "versicolor" "virginica"
+#>   .. .. ..$ enum:List of 3
+#>   .. .. .. ..$ : chr "setosa"
+#>   .. .. .. ..$ : chr "versicolor"
+#>   .. .. .. ..$ : chr "virginica"
 #>   .. ..$ description: chr "Iris species."
 ```
 
@@ -366,8 +381,7 @@ The directory will contain four files: the descriptor `datapackage.json`, one CS
 
 ``` r
 list.files("my_directory")
-#> [1] "datapackage.json"   "iris.csv"           "observations_1.tsv"
-#> [4] "observations_2.tsv"
+#> [1] "datapackage.json"   "iris.csv"           "observations_1.tsv" "observations_2.tsv"
 ```
 
 


### PR DESCRIPTION
Fix #300

``` r
library(frictionless)
example_package()
#> A Data Package (version 1.0) with 3 resources:
#> • deployments
#> • observations
#> • media
#> Use `unclass()` to print the Data Package as a list.

example_package(version = "2.0")
#> A Data Package (version 2.0) with 3 resources:
#> • deployments
#> • observations
#> • media
#> Use `unclass()` to print the Data Package as a list.

x2_custom <- example_package(version = "2.0")
x2_custom$`$schema` <- "https://customprofile.org"
x2_custom
#> A Data Package (version >=2.0) with 3 resources:
#> • deployments
#> • observations
#> • media
#> Use `unclass()` to print the Data Package as a list.

read_package("https://zenodo.org/records/16960867/export/datapackage")
#> A Data Package (version 2.0) with 5 resources:
#> • HG_JUVENILE-gps-2024.csv.gz
#> • HG_JUVENILE-gps-2022.csv.gz
#> • HG_JUVENILE-reference-data.csv
#> • HG_JUVENILE-gps-2023.csv.gz
#> • datapackage.json
#> For more information, see <https://doi.org/10.5281/zenodo.16960867>.
#> Use `unclass()` to print the Data Package as a list.
```

<sup>Created on 2026-07-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>