### PR TITLE
Clarify overwrite behaviour (only true for existing path) in `write_package()`

### DIFF
--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -150,7 +150,7 @@ add_resource <- function(package, resource_name, data, schema = NULL,
     schema <- create_schema(df)
   } else if (is.character(schema)) {
     # Path to schema can be unsafe, since schema will be verbosely included
-    schema <- frictionless:::read_descriptor(schema, safe = FALSE)
+    schema <- read_descriptor(schema, safe = FALSE)
   }
 
   # Check schema (also checks df)

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -150,7 +150,7 @@ add_resource <- function(package, resource_name, data, schema = NULL,
     schema <- create_schema(df)
   } else if (is.character(schema)) {
     # Path to schema can be unsafe, since schema will be verbosely included
-    schema <- read_descriptor(schema, safe = FALSE)
+    schema <- frictionless:::read_descriptor(schema, safe = FALSE)
   }
 
   # Check schema (also checks df)

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -14,8 +14,8 @@
 #' @param data Data to attach, either a data frame or path(s) to CSV file(s):
 #'   - Data frame: attached to the resource as `data` and written to a CSV file
 #'     when using [write_package()].
-#'   - One or more paths to CSV file(s) as a character (vector): added to the
-#'     resource as `path`.
+#'   - One or more paths or URLs to CSV file(s) as a character (vector): added
+#'     to the resource as `path`.
 #'     The last file will be read with [readr::read_delim()] to create or
 #'     compare with `schema` and to set `format`, `mediatype` and `encoding`.
 #'     The other files are ignored, but are expected to have the same structure

--- a/R/write_package.R
+++ b/R/write_package.R
@@ -1,9 +1,32 @@
 #' Write a Data Package to disk
 #'
 #' Writes a Data Package and its related Data Resources to disk as a
-#' `datapackage.json` file.
-#' For some resources, it also writes the data as CSV files.
-#' See `vignette("data-resource")` for details.
+#' `datapackage.json`.
+#' Depending how the data are attached to the Data Resource, the function will
+#' also write or copy these to CSV files.
+#'
+#' @section Writing data to CSV files:
+#'
+#' For Data Resources added or replaced with `add_resource()`, with data
+#' attached as:
+#'
+#' - A data frame: data are written to a CSV file in `directory` using
+#'   `readr::write_csv()` and `path` is added.
+#'   The CSV file will have the same name as the resource and can be compressed
+#'   with `compress = TRUE`.
+#' - One or more paths to local CSV file(s): CSV file(s) are copied to
+#'   `directory` and `path` is updated to the new location.
+#' - URL(s) to CSV file(s): no CSV files are written.
+#'
+#' For existing Data Resources that were not manipulated, with data attached as:
+#'
+#' - One or more paths to local CSV file(s): CSV file(s) are copied to
+#'   `directory` and `path` is updated to the new location.
+#'   Existing CSV files of the same name in `directory` are _not overwritten_.
+#'   This allows you to read and write a `datapackage.json` to the same
+#'   directory, without altering the files of resources you did not manipulate.
+#' - URL(s) to CSV file(s): no CSV files are written.
+#' - Inline data: no CSV files are written.
 #'
 #' @inheritParams read_resource
 #' @param directory Path to local directory to write files to.

--- a/R/write_package.R
+++ b/R/write_package.R
@@ -2,18 +2,20 @@
 #'
 #' Writes a Data Package and its related Data Resources to disk as a
 #' `datapackage.json` and CSV files.
-#' Already existing CSV files of the same name will not be overwritten.
-#' The function can also be used to download a Data Package in its entirety.
 #' The Data Resources are handled as follows:
-#' - Resource `path` has at least one local path (e.g. `deployments.csv`):
-#'   CSV files are copied or downloaded to `directory` and `path` points to new
-#'   location of file(s).
-#' - Resource `path` has only URL(s): resource stays as is.
-#' - Resource has inline `data` originally: resource stays as is.
-#' - Resource has inline `data` as result of adding data with [add_resource()]:
-#'   data are written to a CSV file using [readr::write_csv()], `path` points to
-#'   location of file, `data` property is removed.
-#'   Use `compress = TRUE` to gzip those CSV files.
+#' - For a new resource added with [add_resource()], attached `data` will be
+#'   written to a CSV file in `directory` using [readr::write_csv()]).
+#'   The file will have the same name as the resource, use `compress = TRUE` to
+#'   gzip it.
+#' - For an existing resource with one or more local files in `path`, files will
+#'   be copied to `directory` and `path` will updated to the new location of the
+#'   file(s).
+#'   If the `directory` is the same as the one from which the package was read,
+#'   the resource remains as is and no CSV files will be overwritten.
+#' - For an existing resource with only URLs in `path`, the resource remains as
+#'   is and no CSV files will be written.
+#' - For an existing resource with inline `data`, the resource remains as is and
+#'   no CSV files will be written.
 #' @inheritParams read_resource
 #' @param directory Path to local directory to write files to.
 #' @param compress If `TRUE`, data of added resources will be gzip compressed

--- a/R/write_package.R
+++ b/R/write_package.R
@@ -1,21 +1,10 @@
 #' Write a Data Package to disk
 #'
 #' Writes a Data Package and its related Data Resources to disk as a
-#' `datapackage.json` and CSV files.
-#' The Data Resources are handled as follows:
-#' - For a new resource added with [add_resource()], attached `data` will be
-#'   written to a CSV file in `directory` using [readr::write_csv()]).
-#'   The file will have the same name as the resource, use `compress = TRUE` to
-#'   gzip it.
-#' - For an existing resource with one or more local files in `path`, files will
-#'   be copied to `directory` and `path` will updated to the new location of the
-#'   file(s).
-#'   If the `directory` is the same as the one from which the package was read,
-#'   the resource remains as is and no CSV files will be overwritten.
-#' - For an existing resource with only URLs in `path`, the resource remains as
-#'   is and no CSV files will be written.
-#' - For an existing resource with inline `data`, the resource remains as is and
-#'   no CSV files will be written.
+#' `datapackage.json` file.
+#' For some resources, it also writes the data files.
+#' See `vignette("data-resource")` for details.
+#'
 #' @inheritParams read_resource
 #' @param directory Path to local directory to write files to.
 #' @param compress If `TRUE`, data of added resources will be gzip compressed

--- a/R/write_package.R
+++ b/R/write_package.R
@@ -2,7 +2,7 @@
 #'
 #' Writes a Data Package and its related Data Resources to disk as a
 #' `datapackage.json` file.
-#' For some resources, it also writes the data files.
+#' For some resources, it also writes the data as CSV files.
 #' See `vignette("data-resource")` for details.
 #'
 #' @inheritParams read_resource

--- a/man/add_resource.Rd
+++ b/man/add_resource.Rd
@@ -24,8 +24,8 @@ add_resource(
 \itemize{
 \item Data frame: attached to the resource as \code{data} and written to a CSV file
 when using \code{\link[=write_package]{write_package()}}.
-\item One or more paths to CSV file(s) as a character (vector): added to the
-resource as \code{path}.
+\item One or more paths or URLs to CSV file(s) as a character (vector): added
+to the resource as \code{path}.
 The last file will be read with \code{\link[readr:read_delim]{readr::read_delim()}} to create or
 compare with \code{schema} and to set \code{format}, \code{mediatype} and \code{encoding}.
 The other files are ignored, but are expected to have the same structure

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -20,23 +20,9 @@ before being written to disk (e.g. \code{deployments.csv.gz}).}
 }
 \description{
 Writes a Data Package and its related Data Resources to disk as a
-\code{datapackage.json} and CSV files.
-The Data Resources are handled as follows:
-\itemize{
-\item For a new resource added with \code{\link[=add_resource]{add_resource()}}, attached \code{data} will be
-written to a CSV file in \code{directory} using \code{\link[readr:write_csv]{readr::write_csv()}}).
-The file will have the same name as the resource, use \code{compress = TRUE} to
-gzip it.
-\item For an existing resource with one or more local files in \code{path}, files will
-be copied to \code{directory} and \code{path} will updated to the new location of the
-file(s).
-If the \code{directory} is the same as the one from which the package was read,
-the resource remains as is and no CSV files will be overwritten.
-\item For an existing resource with only URLs in \code{path}, the resource remains as
-is and no CSV files will be written.
-\item For an existing resource with inline \code{data}, the resource remains as is and
-no CSV files will be written.
-}
+\code{datapackage.json} file.
+For some resources, it also writes the data files.
+See \code{vignette("data-resource")} for details.
 }
 \examples{
 # Load the example Data Package from disk

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -21,19 +21,21 @@ before being written to disk (e.g. \code{deployments.csv.gz}).}
 \description{
 Writes a Data Package and its related Data Resources to disk as a
 \code{datapackage.json} and CSV files.
-Already existing CSV files of the same name will not be overwritten.
-The function can also be used to download a Data Package in its entirety.
 The Data Resources are handled as follows:
 \itemize{
-\item Resource \code{path} has at least one local path (e.g. \code{deployments.csv}):
-CSV files are copied or downloaded to \code{directory} and \code{path} points to new
-location of file(s).
-\item Resource \code{path} has only URL(s): resource stays as is.
-\item Resource has inline \code{data} originally: resource stays as is.
-\item Resource has inline \code{data} as result of adding data with \code{\link[=add_resource]{add_resource()}}:
-data are written to a CSV file using \code{\link[readr:write_csv]{readr::write_csv()}}, \code{path} points to
-location of file, \code{data} property is removed.
-Use \code{compress = TRUE} to gzip those CSV files.
+\item For a new resource added with \code{\link[=add_resource]{add_resource()}}, attached \code{data} will be
+written to a CSV file in \code{directory} using \code{\link[readr:write_csv]{readr::write_csv()}}).
+The file will have the same name as the resource, use \code{compress = TRUE} to
+gzip it.
+\item For an existing resource with one or more local files in \code{path}, files will
+be copied to \code{directory} and \code{path} will updated to the new location of the
+file(s).
+If the \code{directory} is the same as the one from which the package was read,
+the resource remains unchanged and no CSV files will be overwritten.
+\item For an existing resource with only URLs in \code{path}, the resource remains
+unchanged and no CSV files will be written.
+\item For an existing resource with inline \code{data}, the resource remains
+unchanged and no CSV files will be written.
 }
 }
 \examples{

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -21,7 +21,7 @@ before being written to disk (e.g. \code{deployments.csv.gz}).}
 \description{
 Writes a Data Package and its related Data Resources to disk as a
 \code{datapackage.json} file.
-For some resources, it also writes the data files.
+For some resources, it also writes the data as CSV files.
 See \code{vignette("data-resource")} for details.
 }
 \examples{

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -31,11 +31,11 @@ gzip it.
 be copied to \code{directory} and \code{path} will updated to the new location of the
 file(s).
 If the \code{directory} is the same as the one from which the package was read,
-the resource remains unchanged and no CSV files will be overwritten.
-\item For an existing resource with only URLs in \code{path}, the resource remains
-unchanged and no CSV files will be written.
-\item For an existing resource with inline \code{data}, the resource remains
-unchanged and no CSV files will be written.
+the resource remains as is and no CSV files will be overwritten.
+\item For an existing resource with only URLs in \code{path}, the resource remains as
+is and no CSV files will be written.
+\item For an existing resource with inline \code{data}, the resource remains as is and
+no CSV files will be written.
 }
 }
 \examples{

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -20,10 +20,37 @@ before being written to disk (e.g. \code{deployments.csv.gz}).}
 }
 \description{
 Writes a Data Package and its related Data Resources to disk as a
-\code{datapackage.json} file.
-For some resources, it also writes the data as CSV files.
-See \code{vignette("data-resource")} for details.
+\code{datapackage.json}.
+Depending how the data are attached to the Data Resource, the function will
+also write or copy these to CSV files.
 }
+\section{Writing data to CSV files}{
+
+
+For Data Resources added or replaced with \code{add_resource()}, with data
+attached as:
+\itemize{
+\item A data frame: data are written to a CSV file in \code{directory} using
+\code{readr::write_csv()} and \code{path} is added.
+The CSV file will have the same name as the resource and can be compressed
+with \code{compress = TRUE}.
+\item One or more paths to local CSV file(s): CSV file(s) are copied to
+\code{directory} and \code{path} is updated to the new location.
+\item URL(s) to CSV file(s): no CSV files are written.
+}
+
+For existing Data Resources that were not manipulated, with data attached as:
+\itemize{
+\item One or more paths to local CSV file(s): CSV file(s) are copied to
+\code{directory} and \code{path} is updated to the new location.
+Existing CSV files of the same name in \code{directory} are \emph{not overwritten}.
+This allows you to read and write a \code{datapackage.json} to the same
+directory, without altering the files of resources you did not manipulate.
+\item URL(s) to CSV file(s): no CSV files are written.
+\item Inline data: no CSV files are written.
+}
+}
+
 \examples{
 # Load the example Data Package from disk
 package <- read_package(

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -87,7 +87,7 @@ my_package
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. For some resources, it also writes the data files. See `vignette("data-resource")` for details.
+`write_package()` writes a package to disk as a `datapackage.json` file. For some resources, it also writes the data as CSV files. See `vignette("data-resource")` for details.
 
 ## Properties implementation
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -87,7 +87,7 @@ my_package
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. For some resources, it also writes the data files. See the function documentation and `vignette("data-resource")` for details.
+`write_package()` writes a package to disk as a `datapackage.json` file. For some resources, it also writes the data files. See `vignette("data-resource")` for details.
 
 ## Properties implementation
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -87,7 +87,7 @@ my_package
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. For some resources, it also writes the data as CSV files. See `vignette("data-resource")` for details.
+`write_package()` writes a package to disk as a `datapackage.json` file. Depending how the data are attached to the resource, the function will also write or copy these to CSV files. See the function documentation for details.
 
 ## Properties implementation
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -73,7 +73,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all the resources. `write_package()` also writes resource data to CSV files, unless the referred data are referred to be URL or inline. See the function documentation for details.
+`write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all the resources. `write_package()` also writes resource data to CSV files, unless the referred data are referred to by URL or inline. See the function documentation for details.
 
 ## Properties implementation
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -73,19 +73,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all resources. For some resources, it also writes the data as CSV files.
-
-For resources added or replaced with `add_resource()`, with data attached as:
-
-- A data frame: data are written to a CSV file (with the same name as the resource) to `directory` using `readr::write_csv()`. `path` is added.
-- One or more paths to local CSV file(s): CSV file(s) are copied to `directory` and `path` is updated to the new location.
-- URL(s) to CSV file(s): no CSV files are written.
-
-For existing resources not manipulated with `add_resource()`, with data attached as:
-
-- One or more paths to local CSV file(s): CSV file(s) are copied to `directory` and `path` is updated to the new location. If the location is the same as before (i.e. reading and writing to the same `directory`), the CSV files won't be overwritten (and keep their original modification timestamp).
-- URL(s) to CSV file(s): no CSV files are written.
-- Inline data: no CSV files are written.
+`write_package()` writes a package to disk as a `datapackage.json` file. Depending how the data are attached to the resource, the function will also write or copy these to CSV files. See the function documentation for details.
 
 ## Properties implementation
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -73,7 +73,19 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all the resources. `write_package()` also writes resource data to CSV files, unless the referred data are referred to by URL or inline. See the function documentation for details.
+`write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all resources. For some resources, the function also writes the data files.
+
+For resources added or replaced with `add_resource()`, with data attached as:
+
+- A data frame: data are written to a CSV file (with the same name as the resource) to `directory` using `readr::write_csv()`. `path` is added.
+- One or more paths to local CSV file(s): CSV file(s) are copied to `directory` and `path` is updated to the new location.
+- URL(s) to CSV file(s): no CSV files are written.
+
+For existing resources not manipulated with `add_resource()`, with data attached as:
+
+- One or more paths to local CSV file(s): CSV file(s) are copied to `directory` and `path` is updated to the new location. If the location is the same as before (i.e. reading and writing to the same `directory`), the CSV files won't be overwritten (and keep their original modification timestamp).
+- URL(s) to CSV file(s): no CSV files are written.
+- Inline data: no CSV files are written.
 
 ## Properties implementation
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -73,7 +73,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all resources. For some resources, the function also writes the data files.
+`write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all resources. For some resources, it also writes the data as CSV files.
 
 For resources added or replaced with `add_resource()`, with data attached as:
 


### PR DESCRIPTION
Originally, `write_package()` stated:

> Already existing CSV files of the same name will not be overwritten.

This was confusing (#144), as it is only true for CSV files that were there when the package was read (since we don't want to overwriting this that were unchanged by the user). For a newly added resource that is written, updated and written again, the CSV files _are_ changed.

This PR updated the documentation to clarify that "not overwritten" only applies to existing resources with `path`. Note that no changes were made to the functionality (as it is how we want it).

PS: this change does not merit an update in NEWS.md