### PR TITLE
Overwrite behavior of `write_package()` is as expected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * `read_package()` now warns when reading a `datapackage.json` that uses a version of the Data Package standard not supported by frictionless (i.e. anything other than version `"1.0"`) (#309).
 * `read_resource()` now supports reading from remote zip files, thanks to support in `{vroom}` (1.3.0) (#291).
 * `write_package()` now prints multiple `resource$path`, `resource$schema$missingValues` and `field$constraints$enum` on multiple lines in the `datapackage.json` (#297).
+* `write_package()`'s overwrite behavior is as intended and now documented in the function (#313).
 * `add_resource()` with `replace = TRUE` adds the resource if there is none to replace, rather than throwing an error (#273).
 * `add_resource()` now retains the URL to a provided schema, rather than including it verbosely (#305).
 * `resources()` is soft-deprecated, please use `resource_names()` instead (#282).

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -14,8 +14,8 @@
 #' @param data Data to attach, either a data frame or path(s) to CSV file(s):
 #'   - Data frame: attached to the resource as `data` and written to a CSV file
 #'     when using [write_package()].
-#'   - One or more paths or URLs to CSV file(s) as a character (vector): added
-#'     to the resource as `path`.
+#'   - One or more paths or URLs to CSV files as a character (vector): added to
+#'     the resource as `path`.
 #'     The last file will be read with [readr::read_delim()] to create or
 #'     compare with `schema` and to set `format`, `mediatype` and `encoding`.
 #'     The other files are ignored, but are expected to have the same structure

--- a/R/write_package.R
+++ b/R/write_package.R
@@ -8,60 +8,49 @@
 #' `write_package()` will write data to CSV files depending on how these are
 #' attached to the Data Resource:
 #'
-#' #### Data frame
+#' - **Data frame**:
+#'   ```R
+#'   add_resource(package, "media", data = df)
+#'   ```
+#'   Data are written to a CSV file in `directory` using [readr::write_csv()].
+#'   The CSV file will have the same name as the resource, overwriting any
+#'   existing file with the same name.
+#'   Use `compress = TRUE` to gzip the CSV file.
 #'
-#' ```R
-#' add_resource(package, "media", data = df)
-#' ```
+#' - One or more **paths** to local CSV files in a **different directory**:
+#'   ```R
+#'   add_resource(package, "media", data = "other-directory/media.csv")
+#'   ```
+#'   CSV files are copied to `directory`, overwriting existing files with
+#'   the same name.
 #'
-#' Data are **written** to a CSV file in `directory` using [readr::write_csv()].
-#' The CSV file will have the same name as the resource, overwriting any
-#' existing file with the same name.
-#' Use `compress = TRUE` to gzip the CSV file.
+#' - One or more **paths** to local CSV files in the **same directory**:
+#'   ```R
+#'   add_resource(package, "media", data = "directory/media.csv")
+#'   ```
+#'   CSV files are left as is (no overwrite).
+#'   This allows you to read and write a `datapackage.json` to the same
+#'   directory, without altering the CSV files of resources you did not
+#'   manipulate.
 #'
-#' #### One or more paths to local CSV files in a _different directory_
+#' - One or more **URLs** to CSV files:
+#'   ```
+#'   add_resource(package, "media", data = "https://example.org/media.csv")
+#'   ```
+#'   Files are not downloaded.
 #'
-#' ```R
-#' add_resource(package, "media", data = "other-directory/media.csv")
-#' ```
+#' - Mix of **URLs and paths** to CSV files:
+#'   ```R
+#'   add_resource(
+#'     package, "media",
+#'     data = c("https://example.org/media.csv", "media.csv")
+#'   )
+#'   ```
+#'   Remote CSV files are downloaded to `directory`, overwriting existing
+#'   files with the same name.
+#'   Local CSV files are handled as described above.
 #'
-#' CSV files are **copied** to `directory`, overwriting existing files with the
-#' same name.
-#'
-#' #### One or more paths to local CSV files in the _same directory_
-#'
-#' ```R
-#' add_resource(package, "media", data = "directory/media.csv")
-#' ```
-#'
-#' CSV files are left **as is** (no overwrite).
-#' This allows you to read and write a `datapackage.json` to the same directory,
-#' without altering the CSV files of resources you did not manipulate.
-#'
-#' #### One or more URLs to CSV files
-#'
-#' ```
-#' add_resource(package, "media", data = "https://example.org/media.csv")
-#' ```
-#'
-#' Files are **not downloaded**.
-#'
-#' #### Mix of URLs and paths to CSV files
-#'
-#' ```R
-#' add_resource(
-#'   package, "media",
-#'   data = c("https://example.org/media.csv", "media.csv")
-#' )
-#' ```
-#'
-#' Remote CSV files are **downloaded** to `directory`, overwriting existing
-#' files with the same name.
-#' Local CSV files are handled as described above.
-#'
-#' #### Inline data
-#'
-#' **No files are written**.
+#' - **Inline data**: No files are written.
 #'
 #' In all above cases `path` is added or updated to the new file location(s)
 #' when appropriate.

--- a/R/write_package.R
+++ b/R/write_package.R
@@ -1,32 +1,70 @@
 #' Write a Data Package to disk
 #'
 #' Writes a Data Package and its related Data Resources to disk as a
-#' `datapackage.json`.
-#' Depending how the data are attached to the Data Resource, the function will
-#' also write or copy these to CSV files.
+#' `datapackage.json` and CSV files.
 #'
 #' @section Writing data to CSV files:
 #'
-#' For Data Resources added or replaced with `add_resource()`, with data
-#' attached as:
+#' `write_package()` will write data to CSV files depending on how these are
+#' attached to the Data Resource:
 #'
-#' - A data frame: data are written to a CSV file in `directory` using
-#'   `readr::write_csv()` and `path` is added.
-#'   The CSV file will have the same name as the resource and can be compressed
-#'   with `compress = TRUE`.
-#' - One or more paths to local CSV file(s): CSV file(s) are copied to
-#'   `directory` and `path` is updated to the new location.
-#' - URL(s) to CSV file(s): no CSV files are written.
+#' #### Data frame
 #'
-#' For existing Data Resources that were not manipulated, with data attached as:
+#' ```R
+#' add_resource(package, "media", data = df)
+#' ```
 #'
-#' - One or more paths to local CSV file(s): CSV file(s) are copied to
-#'   `directory` and `path` is updated to the new location.
-#'   Existing CSV files of the same name in `directory` are _not overwritten_.
-#'   This allows you to read and write a `datapackage.json` to the same
-#'   directory, without altering the files of resources you did not manipulate.
-#' - URL(s) to CSV file(s): no CSV files are written.
-#' - Inline data: no CSV files are written.
+#' Data are **written** to a CSV file in `directory` using [readr::write_csv()].
+#' The CSV file will have the same name as the resource, overwriting any
+#' existing file with the same name.
+#' Use `compress = TRUE` to gzip the CSV file.
+#'
+#' #### One or more paths to local CSV files in a _different directory_
+#'
+#' ```R
+#' add_resource(package, "media", data = "other-directory/media.csv")
+#' ```
+#'
+#' CSV files are **copied** to `directory`, overwriting existing files with the
+#' same name.
+#'
+#' #### One or more paths to local CSV files in the _same directory_
+#'
+#' ```R
+#' add_resource(package, "media", data = "directory/media.csv")
+#' ```
+#'
+#' CSV files are left **as is** (no overwrite).
+#' This allows you to read and write a `datapackage.json` to the same directory,
+#' without altering the CSV files of resources you did not manipulate.
+#'
+#' #### One or more URLs to CSV files
+#'
+#' ```
+#' add_resource(package, "media", data = "https://example.org/media.csv")
+#' ```
+#'
+#' Files are **not downloaded**.
+#'
+#' #### Mix of URLs and paths to CSV files
+#'
+#' ```R
+#' add_resource(
+#'   package, "media",
+#'   data = c("https://example.org/media.csv", "media.csv")
+#' )
+#' ```
+#'
+#' Remote CSV files are **downloaded** to `directory`, overwriting existing
+#' files with the same name.
+#' Local CSV files are handled as described above.
+#'
+#' #### Inline data
+#'
+#' **No files are written**.
+#'
+#' In all above cases `path` is added or updated to the new file location(s)
+#' when appropriate.
 #'
 #' @inheritParams read_resource
 #' @param directory Path to local directory to write files to.

--- a/R/write_resource.R
+++ b/R/write_resource.R
@@ -55,12 +55,9 @@ write_resource <- function(package, resource_name, directory = ".",
         # Only replaced resources will be overwritten, not existing files
         if (isTRUE(attr(resource, "path") == "added") && file.exists(destination)) {
           file.remove(destination)
-          # file.copy fails silently with overwrite = TRUE
-          file.copy(path, destination)
-        } else {
-          file.copy(path, destination, overwrite = FALSE)
+          }
+        file.copy(path, destination, overwrite = FALSE)
         }
-      }
       out_paths <- append(out_paths, file_name)
     }
     if (length(out_paths) > 1) {

--- a/R/write_resource.R
+++ b/R/write_resource.R
@@ -53,7 +53,7 @@ write_resource <- function(package, resource_name, directory = ".",
         }
       } else {
         # Only replaced resources will be overwritten, not existing files
-        if (isTRUE(attr(resource, "path") == "added") && file.exists(destination)) {
+        if (path != destination && file.exists(destination)) {
           file.remove(destination)
           }
         file.copy(path, destination, overwrite = FALSE)

--- a/R/write_resource.R
+++ b/R/write_resource.R
@@ -37,12 +37,12 @@ write_resource <- function(package, resource_name, directory = ".",
 
   # Resource has local paths (optionally mixed with URLs)
   } else if (data_location == "path") {
-    # Download or copy file to directory, point path to file name (in that dir)
-    # Note that existing files will not be overwritten
     out_paths <- vector()
     for (path in resource$path) {
       file_name <- basename(path)
       destination <- file.path(directory, file_name)
+
+      # Download file to destination
       if (is_url(path)) {
         if (!file.exists(destination)) {
           cli::cli_inform(
@@ -51,13 +51,14 @@ write_resource <- function(package, resource_name, directory = ".",
           )
           utils::download.file(path, destination, quiet = TRUE)
         }
+
+      # Copy file to destination, but don't overwrite if it was read from there
       } else {
-        # Only replaced resources will be overwritten, not existing files
         if (path != destination && file.exists(destination)) {
           file.remove(destination)
-          }
-        file.copy(path, destination, overwrite = FALSE)
         }
+        file.copy(path, destination, overwrite = FALSE)
+      }
       out_paths <- append(out_paths, file_name)
     }
     if (length(out_paths) > 1) {

--- a/R/write_resource.R
+++ b/R/write_resource.R
@@ -52,7 +52,14 @@ write_resource <- function(package, resource_name, directory = ".",
           utils::download.file(path, destination, quiet = TRUE)
         }
       } else {
-        file.copy(path, destination, overwrite = FALSE)
+        # Only replaced resources will be overwritten, not existing files
+        if (isTRUE(attr(resource, "path") == "added") && file.exists(destination)) {
+          file.remove(destination)
+          # file.copy fails silently with overwrite = TRUE
+          file.copy(path, destination)
+        } else {
+          file.copy(path, destination, overwrite = FALSE)
+        }
       }
       out_paths <- append(out_paths, file_name)
     }

--- a/man/add_resource.Rd
+++ b/man/add_resource.Rd
@@ -24,8 +24,8 @@ add_resource(
 \itemize{
 \item Data frame: attached to the resource as \code{data} and written to a CSV file
 when using \code{\link[=write_package]{write_package()}}.
-\item One or more paths or URLs to CSV file(s) as a character (vector): added
-to the resource as \code{path}.
+\item One or more paths or URLs to CSV files as a character (vector): added to
+the resource as \code{path}.
 The last file will be read with \code{\link[readr:read_delim]{readr::read_delim()}} to create or
 compare with \code{schema} and to set \code{format}, \code{mediatype} and \code{encoding}.
 The other files are ignored, but are expected to have the same structure

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -20,34 +20,70 @@ before being written to disk (e.g. \code{deployments.csv.gz}).}
 }
 \description{
 Writes a Data Package and its related Data Resources to disk as a
-\code{datapackage.json}.
-Depending how the data are attached to the Data Resource, the function will
-also write or copy these to CSV files.
+\code{datapackage.json} and CSV files.
 }
 \section{Writing data to CSV files}{
 
 
-For Data Resources added or replaced with \code{add_resource()}, with data
-attached as:
-\itemize{
-\item A data frame: data are written to a CSV file in \code{directory} using
-\code{readr::write_csv()} and \code{path} is added.
-The CSV file will have the same name as the resource and can be compressed
-with \code{compress = TRUE}.
-\item One or more paths to local CSV file(s): CSV file(s) are copied to
-\code{directory} and \code{path} is updated to the new location.
-\item URL(s) to CSV file(s): no CSV files are written.
+\code{write_package()} will write data to CSV files depending on how these are
+attached to the Data Resource:
+\subsection{Data frame}{
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(package, "media", data = df)
+}\if{html}{\out{</div>}}
+
+Data are \strong{written} to a CSV file in \code{directory} using \code{\link[readr:write_csv]{readr::write_csv()}}.
+The CSV file will have the same name as the resource, overwriting any
+existing file with the same name.
+Use \code{compress = TRUE} to gzip the CSV file.
 }
 
-For existing Data Resources that were not manipulated, with data attached as:
-\itemize{
-\item One or more paths to local CSV file(s): CSV file(s) are copied to
-\code{directory} and \code{path} is updated to the new location.
-Existing CSV files of the same name in \code{directory} are \emph{not overwritten}.
-This allows you to read and write a \code{datapackage.json} to the same
-directory, without altering the files of resources you did not manipulate.
-\item URL(s) to CSV file(s): no CSV files are written.
-\item Inline data: no CSV files are written.
+\subsection{One or more paths to local CSV files in a \emph{different directory}}{
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(package, "media", data = "other-directory/media.csv")
+}\if{html}{\out{</div>}}
+
+CSV files are \strong{copied} to \code{directory}, overwriting existing files with the
+same name.
+}
+
+\subsection{One or more paths to local CSV files in the \emph{same directory}}{
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(package, "media", data = "directory/media.csv")
+}\if{html}{\out{</div>}}
+
+CSV files are left \strong{as is} (no overwrite).
+This allows you to read and write a \code{datapackage.json} to the same directory,
+without altering the CSV files of resources you did not manipulate.
+}
+
+\subsection{One or more URLs to CSV files}{
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{add_resource(package, "media", data = "https://example.org/media.csv")
+}\if{html}{\out{</div>}}
+
+Files are \strong{not downloaded}.
+}
+
+\subsection{Mix of URLs and paths to CSV files}{
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(
+  package, "media",
+  data = c("https://example.org/media.csv", "media.csv")
+)
+}\if{html}{\out{</div>}}
+
+Remote CSV files are \strong{downloaded} to \code{directory}, overwriting existing
+files with the same name.
+Local CSV files are handled as described above.
+}
+
+\subsection{Inline data}{
+
+\strong{No files are written}.
+
+In all above cases \code{path} is added or updated to the new file location(s)
+when appropriate.
 }
 }
 

--- a/man/write_package.Rd
+++ b/man/write_package.Rd
@@ -27,45 +27,39 @@ Writes a Data Package and its related Data Resources to disk as a
 
 \code{write_package()} will write data to CSV files depending on how these are
 attached to the Data Resource:
-\subsection{Data frame}{
+\itemize{
+\item \strong{Data frame}:
 
 \if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(package, "media", data = df)
 }\if{html}{\out{</div>}}
 
-Data are \strong{written} to a CSV file in \code{directory} using \code{\link[readr:write_csv]{readr::write_csv()}}.
+Data are written to a CSV file in \code{directory} using \code{\link[readr:write_csv]{readr::write_csv()}}.
 The CSV file will have the same name as the resource, overwriting any
 existing file with the same name.
 Use \code{compress = TRUE} to gzip the CSV file.
-}
-
-\subsection{One or more paths to local CSV files in a \emph{different directory}}{
+\item One or more \strong{paths} to local CSV files in a \strong{different directory}:
 
 \if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(package, "media", data = "other-directory/media.csv")
 }\if{html}{\out{</div>}}
 
-CSV files are \strong{copied} to \code{directory}, overwriting existing files with the
-same name.
-}
-
-\subsection{One or more paths to local CSV files in the \emph{same directory}}{
+CSV files are copied to \code{directory}, overwriting existing files with
+the same name.
+\item One or more \strong{paths} to local CSV files in the \strong{same directory}:
 
 \if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(package, "media", data = "directory/media.csv")
 }\if{html}{\out{</div>}}
 
-CSV files are left \strong{as is} (no overwrite).
-This allows you to read and write a \code{datapackage.json} to the same directory,
-without altering the CSV files of resources you did not manipulate.
-}
-
-\subsection{One or more URLs to CSV files}{
+CSV files are left as is (no overwrite).
+This allows you to read and write a \code{datapackage.json} to the same
+directory, without altering the CSV files of resources you did not
+manipulate.
+\item One or more \strong{URLs} to CSV files:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{add_resource(package, "media", data = "https://example.org/media.csv")
 }\if{html}{\out{</div>}}
 
-Files are \strong{not downloaded}.
-}
-
-\subsection{Mix of URLs and paths to CSV files}{
+Files are not downloaded.
+\item Mix of \strong{URLs and paths} to CSV files
 
 \if{html}{\out{<div class="sourceCode R">}}\preformatted{add_resource(
   package, "media",
@@ -73,18 +67,14 @@ Files are \strong{not downloaded}.
 )
 }\if{html}{\out{</div>}}
 
-Remote CSV files are \strong{downloaded} to \code{directory}, overwriting existing
+Remote CSV files are downloaded to \code{directory}, overwriting existing
 files with the same name.
 Local CSV files are handled as described above.
+\item \strong{Inline data}: No files are written.
 }
-
-\subsection{Inline data}{
-
-\strong{No files are written}.
 
 In all above cases \code{path} is added or updated to the new file location(s)
 when appropriate.
-}
 }
 
 \examples{

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -60,54 +60,51 @@ test_that("write_package() writes unaltered datapackage.json as is", {
 
 test_that("write_package() overwrites files only if necessary", {
   skip_if_offline()
-
-  # P0 - Create local data package with resource "df"
-  p0 <- create_package() |>
-    add_resource("df", df) |>
-    add_resource("media", test_path("data/media.csv"))
-
-  dir <- "bla" # file.path(tempdir(), "package")
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
-  suppressMessages(write_package(p0, dir))
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
 
-  # Read filestamps
-  p0_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
-  p0_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
-
-  # Ensure mtime can change if file is rewritten
-  Sys.sleep(1.1)
-
-  # P1 - Read p0 and write again unchanged, CSV files should not be overwritten
-  p1 <- read_package(file.path(dir, "datapackage.json"))
+  # Step 1: create package and write to dir
+  p1 <-
+    create_package() |>
+    add_resource("media", test_path("data/media.csv")) |>
+    add_resource("df", df)
   suppressMessages(write_package(p1, dir))
 
-  p1_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
-  p1_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
+  # Get file modification timestamps
+  t1_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
+  t1_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
 
-  expect_identical(p0_media_mtime, p1_media_mtime)
-  expect_identical(p0_df_mtime, p1_df_mtime)
-
+  # Step 2: wait a bit, read package and write to same dir unchanged
   Sys.sleep(1.1)
-
-  # P2 - Replace resources, 2 different situations
-  p2 <- read_package(file.path(dir, "datapackage.json")) |>
-    add_resource("df", test_path("data/df.csv"), replace = TRUE) |>
-    add_resource("media", file.path(dir, "media.csv"), replace = TRUE)
+  p2 <- read_package(file.path(dir, "datapackage.json"))
   suppressMessages(write_package(p2, dir))
 
-  p2_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
-  p2_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
+  # Get file modification timestamps
+  t2_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
+  t2_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
 
-  # Media file is replaced with same file from same path, so not overwritten
-  expect_identical(p0_media_mtime, p2_media_mtime)
-  # Media file is replaced with file from different path, so overwritten
-  expect_failure(expect_identical(p0_df_mtime, p2_df_mtime))
-  expect_identical(
-    readr::read_csv(file.path(dir, "df.csv"), show_col_types = FALSE),
-    readr::read_csv(test_path("data/df.csv"), show_col_types = FALSE)
-  )
+  # Expect no file overwrites
+  expect_identical(t2_media_mtime, t1_media_mtime)
+  expect_identical(t2_df_mtime, t1_df_mtime)
+
+  # Step 3: wait a bit, read package, change resources and write to same dir
+  Sys.sleep(1.1)
+  p3 <-
+    read_package(file.path(dir, "datapackage.json")) |>
+    add_resource("media", file.path(dir, "media.csv"), replace = TRUE) |>
+    add_resource("df", test_path("data/df.csv"), replace = TRUE)
+  suppressMessages(write_package(p3, dir))
+
+  # Get file modification timestamps
+  t3_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
+  t3_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
+
+  # Expect no file overwrite for media.csv, as it was read from same dir
+  expect_identical(t3_media_mtime, t2_media_mtime)
+
+  # Expect file overwrite for df.csv, as it was read from different dir
+  expect_gt(t3_df_mtime, t2_df_mtime)
 })
 
 test_that("write_package() copies file(s) for path = local in local package", {

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -58,34 +58,6 @@ test_that("write_package() writes unaltered datapackage.json as is", {
   expect_identical(json_as_written, json_original)
 })
 
-test_that("write_package() does not overwrite existing data files", {
-  skip_if_offline()
-  p <- example_package()
-
-  # Change local path to URL
-  p$resources[[1]]$path <- file.path(
-    "https://raw.githubusercontent.com/frictionlessdata/frictionless-r",
-    "main/inst/extdata/v1/deployments.csv"
-  )
-  dir <- "fail" # file.path(tempdir(), "package")
-  on.exit(unlink(dir, recursive = TRUE))
-  dir.create(dir)
-
-  # Create files in directory
-  files <- c(
-    datapackage = file.path(dir, "datapackage.json"),
-    # deployments: has remote path, should not be written
-    observations_1 = file.path(dir, "observations_1.tsv"),
-    observations_2 = file.path(dir, "observations_2.tsv")
-  )
-  file.create(files) # Size for these files will be 0
-
-  # Write package to directory, expect only datapackage.json is overwritten
-  suppressMessages(write_package(p, dir))
-  expect_gt(file.info(files["datapackage"])$size, 0) # Overwritten
-  expect_identical(file.info(files["observations_1"])$size, 0) # Remains same
-})
-
 test_that("write_package() overwrite behaviour is as expected", {
   skip_if_offline()
 

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -61,45 +61,55 @@ test_that("write_package() writes unaltered datapackage.json as is", {
 test_that("write_package() overwrite behaviour is as expected", {
   skip_if_offline()
 
-  # Create local data package with resource "df"
+  # P0 - Create local data package with resource "df"
   df <- data.frame(
     deployment_id = 1:3,
     ind_names = c("Shakira", "Tony", "Claire")
   )
-  p <- example_package() |>
-    add_resource("df", df)
+  p0 <- create_package() |>
+    add_resource("df", df) |>
+    add_resource("media", test_path("data/media.csv"))
 
-  dir <- file.path(tempdir(), "package")
+  dir <- "bla" # file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
-  p_before <- suppressMessages(write_package(p, dir))
+  suppressMessages(write_package(p0, dir))
 
   # Read filestamps
-  deployments_before <- file.path(dir, "deployments.csv")
-  before_mtime <- file.info(deployments_before)$mtime
+  p0_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
+  p0_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
 
   # Ensure mtime can change if file is rewritten
   Sys.sleep(1.1)
 
-  # Replace resource "df" with different data frame with same name "df.csv"
-  p_after <-
-    read_package(file.path(dir, "datapackage.json")) |>
-    add_resource("df", test_path("data/df.csv"), replace = TRUE)
-  suppressMessages(write_package(p_after, dir))
+  # P1 - Read p0 and write again unchanged, CSV files should not be overwritten
+  p1 <- read_package(file.path(dir, "datapackage.json"))
+  suppressMessages(write_package(p1, dir))
 
-  # Read filestamps
-  deployments_after <- file.path(dir, "deployments.csv")
-  after_mtime <- file.info(deployments_after)$mtime
+  p1_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
+  p1_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
 
-  df_overwritten <-
-    readr::read_csv(file.path(dir, "df.csv"), show_col_types = FALSE)
+  expect_identical(p0_media_mtime, p1_media_mtime)
+  expect_identical(p0_df_mtime, p1_df_mtime)
 
-  # Test that the df file was overwritten
+  Sys.sleep(1.1)
+
+  # P2 - Replace resources, 2 different situations
+  p2 <- read_package(file.path(dir, "datapackage.json")) |>
+    add_resource("df", test_path("data/df.csv"), replace = TRUE) |>
+    add_resource("media", file.path(dir, "media.csv"), replace = TRUE)
+  suppressMessages(write_package(p2, dir))
+
+  p2_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
+  p2_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
+
+  # Media file is replaced with same file from same path, so not overwritten
+  expect_identical(p0_media_mtime, p2_media_mtime)
+  # Media file is replaced with file from different path, so overwritten
+  expect_failure(expect_identical(p0_df_mtime, p2_df_mtime))
   expect_identical(
-    df_overwritten,
+    readr::read_csv(file.path(dir, "df.csv"), show_col_types = FALSE),
     readr::read_csv(test_path("data/df.csv"), show_col_types = FALSE)
   )
-  # Test that the deployments file was not overwritten (mtime unchanged)
-  expect_identical(before_mtime, after_mtime)
 })
 
 test_that("write_package() copies file(s) for path = local in local package", {

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -86,6 +86,35 @@ test_that("write_package() does not overwrite existing data files", {
   expect_identical(file.info(files["observations_1"])$size, 0) # Remains same
 })
 
+test_that("write_package() overwrites replaced resource originating from
+          different local path", {
+  skip_if_offline()
+
+  # Create local data package with resource "df"
+  df <- data.frame(
+    deployment_id = 1:3,
+    ind_names = c("Shakira", "Tony", "Claire")
+  )
+  p <- example_package() |>
+    add_resource("df", df)
+
+  dir <- file.path(tempdir(), "package")
+  on.exit(unlink(dir, recursive = TRUE))
+  p_local <- suppressMessages(write_package(p, dir))
+
+  # Replace resource "df" with different data frame with same name "df.csv"
+  p_replaced_from_path <-
+    add_resource(p_local, "df", test_path("data/df.csv"), replace = TRUE)
+  suppressMessages(write_package(p_replaced_from_path, dir))
+
+  df_overwritten <-
+    readr::read_csv(file.path(dir, "df.csv"), show_col_types = FALSE)
+  expect_identical(
+    df_overwritten,
+    readr::read_csv(test_path("data/df.csv"), show_col_types = FALSE)
+  )
+})
+
 test_that("write_package() copies file(s) for path = local in local package", {
   skip_if_offline()
   p <- example_package()
@@ -96,7 +125,7 @@ test_that("write_package() copies file(s) for path = local in local package", {
     "main/inst/extdata/v1/observations_1.tsv"
   )
   p <- add_resource(p, "new", test_path("data/df.csv"))
-  dir <- file.path(tempdir(), "package")
+  dir <- "fail" #file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   p_written <- suppressMessages(write_package(p, dir))
 
@@ -389,33 +418,4 @@ test_that("write_package() writes NULL and NA as null", {
   expect_null(p_reread$null_property) # Write should remove this property
   expect_null(purrr::chuck(p_reread, "na_property"))
   expect_null(purrr::chuck(p_reread, "resources", 4, "na_property"))
-})
-
-test_that("write_package() overwrites replaced resource originating from local
-          path", {
-  skip_if_offline()
-
-  # Create local data package with resource "df"
-  df <- data.frame(
-    deployment_id = 1:3,
-    ind_names = c("Shakira", "Tony", "Claire")
-  )
-  p <- example_package() |>
-    add_resource("df", df)
-
-  dir <- file.path(tempdir(), "package")
-  on.exit(unlink(dir, recursive = TRUE))
-  p_local <- suppressMessages(write_package(p, dir))
-
-  # Replace resource "df" with different data frame with same name "df.csv"
-  p_replaced_from_path <-
-    add_resource(p_local, "df", test_path("data/df.csv"), replace = TRUE)
-  suppressMessages(write_package(p_replaced_from_path, dir))
-
-  df_overwritten <-
-    readr::read_csv(file.path(dir, "df.csv"), show_col_types = FALSE)
-  expect_identical(
-    df_overwritten,
-    readr::read_csv(test_path("data/df.csv"), show_col_types = FALSE)
-  )
 })

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -67,7 +67,7 @@ test_that("write_package() does not overwrite existing data files", {
     "https://raw.githubusercontent.com/frictionlessdata/frictionless-r",
     "main/inst/extdata/v1/deployments.csv"
   )
-  dir <- file.path(tempdir(), "package")
+  dir <- "fail" # file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   dir.create(dir)
 
@@ -86,8 +86,7 @@ test_that("write_package() does not overwrite existing data files", {
   expect_identical(file.info(files["observations_1"])$size, 0) # Remains same
 })
 
-test_that("write_package() overwrites replaced resource originating from
-          different local path", {
+test_that("write_package() overwrite behaviour is as expected", {
   skip_if_offline()
 
   # Create local data package with resource "df"
@@ -100,19 +99,35 @@ test_that("write_package() overwrites replaced resource originating from
 
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
-  p_local <- suppressMessages(write_package(p, dir))
+  p_before <- suppressMessages(write_package(p, dir))
+
+  # Read filestamps
+  deployments_before <- file.path(dir, "deployments.csv")
+  before_mtime <- file.info(deployments_before)$mtime
+
+  # Ensure mtime can change if file is rewritten
+  Sys.sleep(1.1)
 
   # Replace resource "df" with different data frame with same name "df.csv"
-  p_replaced_from_path <-
-    add_resource(p_local, "df", test_path("data/df.csv"), replace = TRUE)
-  suppressMessages(write_package(p_replaced_from_path, dir))
+  p_after <-
+    read_package(file.path(dir, "datapackage.json")) |>
+    add_resource("df", test_path("data/df.csv"), replace = TRUE)
+  suppressMessages(write_package(p_after, dir))
+
+  # Read filestamps
+  deployments_after <- file.path(dir, "deployments.csv")
+  after_mtime <- file.info(deployments_after)$mtime
 
   df_overwritten <-
     readr::read_csv(file.path(dir, "df.csv"), show_col_types = FALSE)
+
+  # Test that the df file was overwritten
   expect_identical(
     df_overwritten,
     readr::read_csv(test_path("data/df.csv"), show_col_types = FALSE)
   )
+  # Test that the deployments file was not overwritten (mtime unchanged)
+  expect_identical(before_mtime, after_mtime)
 })
 
 test_that("write_package() copies file(s) for path = local in local package", {

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -58,21 +58,19 @@ test_that("write_package() writes unaltered datapackage.json as is", {
   expect_identical(json_as_written, json_original)
 })
 
-test_that("write_package() overwrite behaviour is as expected", {
+test_that("write_package() overwrites files only if necessary", {
   skip_if_offline()
 
   # P0 - Create local data package with resource "df"
-  df <- data.frame(
-    deployment_id = 1:3,
-    ind_names = c("Shakira", "Tony", "Claire")
-  )
   p0 <- create_package() |>
     add_resource("df", df) |>
     add_resource("media", test_path("data/media.csv"))
 
   dir <- "bla" # file.path(tempdir(), "package")
+  dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   suppressMessages(write_package(p0, dir))
+  df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
 
   # Read filestamps
   p0_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
@@ -122,7 +120,7 @@ test_that("write_package() copies file(s) for path = local in local package", {
     "main/inst/extdata/v1/observations_1.tsv"
   )
   p <- add_resource(p, "new", test_path("data/df.csv"))
-  dir <- "fail" #file.path(tempdir(), "package")
+  dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   p_written <- suppressMessages(write_package(p, dir))
 

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -64,18 +64,30 @@ test_that("write_package() overwrites files only if necessary", {
   on.exit(unlink(dir, recursive = TRUE))
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
 
-  # Step 1: create package and write to dir
-  p1 <-
+  # STEP 0: create package and write to dir
+  p0 <-
     create_package() |>
     add_resource("media", test_path("data/media.csv")) |>
     add_resource("df", df)
-  suppressMessages(write_package(p1, dir))
+  suppressMessages(write_package(p0, dir))
+
+  # Get file modification timestamps
+  t0_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
+  t0_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
+
+  # STEP 1: wait a bit, and write package to same dir
+  Sys.sleep(1.1)
+  suppressMessages(write_package(p0, dir))
 
   # Get file modification timestamps
   t1_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
   t1_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
 
-  # Step 2: wait a bit, read package and write to same dir unchanged
+  # Expect file overwrites, since resources in loaded package might have changed
+  expect_gt(t1_media_mtime, t0_media_mtime)
+  expect_gt(t1_df_mtime, t0_df_mtime)
+
+  # STEP 2: wait a bit, read package and write to same dir unchanged
   Sys.sleep(1.1)
   p2 <- read_package(file.path(dir, "datapackage.json"))
   suppressMessages(write_package(p2, dir))
@@ -84,11 +96,11 @@ test_that("write_package() overwrites files only if necessary", {
   t2_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
   t2_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
 
-  # Expect no file overwrites
+  # Expect NO file overwrites, since the read package was unchanged
   expect_identical(t2_media_mtime, t1_media_mtime)
   expect_identical(t2_df_mtime, t1_df_mtime)
 
-  # Step 3: wait a bit, read package, change resources and write to same dir
+  # STEP 3: wait a bit, read package, change resources and write to same dir
   Sys.sleep(1.1)
   p3 <-
     read_package(file.path(dir, "datapackage.json")) |>
@@ -100,7 +112,7 @@ test_that("write_package() overwrites files only if necessary", {
   t3_media_mtime <- file.info(file.path(dir, "media.csv"))$mtime
   t3_df_mtime <- file.info(file.path(dir, "df.csv"))$mtime
 
-  # Expect no file overwrite for media.csv, as it was read from same dir
+  # Expect NO file overwrite for media.csv, as it was read from same dir
   expect_identical(t3_media_mtime, t2_media_mtime)
 
   # Expect file overwrite for df.csv, as it was read from different dir

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -390,3 +390,32 @@ test_that("write_package() writes NULL and NA as null", {
   expect_null(purrr::chuck(p_reread, "na_property"))
   expect_null(purrr::chuck(p_reread, "resources", 4, "na_property"))
 })
+
+test_that("write_package() overwrites replaced resource originating from local
+          path", {
+  skip_if_offline()
+
+  # Create local data package with resource "df"
+  df <- data.frame(
+    deployment_id = 1:3,
+    ind_names = c("Shakira", "Tony", "Claire")
+  )
+  p <- example_package() |>
+    add_resource("df", df)
+
+  dir <- file.path(tempdir(), "package")
+  on.exit(unlink(dir, recursive = TRUE))
+  p_local <- suppressMessages(write_package(p, dir))
+
+  # Replace resource "df" with different data frame with same name "df.csv"
+  p_replaced_from_path <-
+    add_resource(p_local, "df", test_path("data/df.csv"), replace = TRUE)
+  suppressMessages(write_package(p_replaced_from_path, dir))
+
+  df_overwritten <-
+    readr::read_csv(file.path(dir, "df.csv"), show_col_types = FALSE)
+  expect_identical(
+    df_overwritten,
+    readr::read_csv(test_path("data/df.csv"), show_col_types = FALSE)
+  )
+})

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -60,7 +60,7 @@ test_that("write_package() writes unaltered datapackage.json as is", {
 
 test_that("write_package() overwrites files only if necessary", {
   skip_if_offline()
-  dir <- "output"
+  dir <- "output" # file.path(tempdir(), "package") fails on Windows :-/
   on.exit(unlink(dir, recursive = TRUE))
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
 

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -60,7 +60,7 @@ test_that("write_package() writes unaltered datapackage.json as is", {
 
 test_that("write_package() overwrites files only if necessary", {
   skip_if_offline()
-  dir <- file.path(tempdir(), "package")
+  dir <- "output"
   on.exit(unlink(dir, recursive = TRUE))
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -87,7 +87,7 @@ my_package
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. Depending how the data are attached to the resource, the function will also write or copy these to CSV files. See the function documentation for details.
+`write_package()` writes a package and its related resources to disk as a `datapackage.json` and CSV files. See the function documentation for details.
 
 ## Properties implementation
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -83,7 +83,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### Write
 
-`write_package()` writes a package to disk as a `datapackage.json` file. Depending how the data are attached to the resource, the function will also write or copy these to CSV files. See the function documentation for details.
+`write_package()` writes a package and its related resources to disk as a `datapackage.json` and CSV files. See the function documentation for details.
 
 ## Properties implementation
 


### PR DESCRIPTION
fix #308 

<img width="1113" height="836" alt="image" src="https://github.com/user-attachments/assets/2330ebec-5451-4c23-be19-7af2561a6962" />

TODO:

- [ ] Update write_resource documentation
