### PR TITLE
Adds revdep directory

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^CRAN-SUBMISSION$
 ^\.positai$
 ^\.claude$
+^revdep$

--- a/revdep/.gitignore
+++ b/revdep/.gitignore
@@ -1,0 +1,7 @@
+checks
+library
+checks.noindex
+library.noindex
+cloud.noindex
+data.sqlite
+*.html

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,0 +1,31 @@
+# Platform
+
+|field    |value                                                                       |
+|:--------|:---------------------------------------------------------------------------|
+|version  |R version 4.5.3 (2026-03-11)                                                |
+|os       |macOS Tahoe 26.5.2                                                          |
+|system   |aarch64, darwin20                                                           |
+|ui       |RStudio                                                                     |
+|language |(EN)                                                                        |
+|collate  |en_US.UTF-8                                                                 |
+|ctype    |en_US.UTF-8                                                                 |
+|tz       |Europe/Brussels                                                             |
+|date     |2026-07-30                                                                  |
+|rstudio  |2026.06.0+242 Blue Plumbago (desktop)                                       |
+|pandoc   |NA                                                                          |
+|quarto   |1.9.38 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/quarto |
+
+# Dependencies
+
+|package      |old   |new        |Δ  |
+|:------------|:-----|:----------|:--|
+|frictionless |1.2.1 |1.2.1.9000 |*  |
+
+# Revdeps
+
+## New problems (1)
+
+|package   |version |error  |warning |note |
+|:---------|:-------|:------|:-------|:----|
+|[camtrapdp](problems.md#camtrapdp)|0.5.0   |__+1__ |        |     |
+

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,0 +1,15 @@
+## revdepcheck results
+
+We checked 2 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 1 new problems
+ * We failed to check 0 packages
+
+Issues with CRAN packages are summarised below.
+
+### New problems
+(This reports the first line of each new failure)
+
+* camtrapdp
+  checking tests ...
+

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,0 +1,1 @@
+*Wow, no problems at all. :)*

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,0 +1,33 @@
+# camtrapdp (0.5.0)
+
+* GitHub: <https://github.com/inbo/camtrapdp>
+* Email: <mailto:peter.desmet@inbo.be>
+* GitHub mirror: <https://github.com/cran/camtrapdp>
+
+Run `revdepcheck::revdep_details(, "camtrapdp")` for more info
+
+## Newly broken
+
+*   checking tests ...
+     ```
+       Running ‘testthat.R’
+      ERROR
+     Running the tests in ‘tests/testthat.R’ failed.
+     Last 13 lines of output:
+       Expected `read_camtrapdp(file.path(temp_dir_merged, "datapackage_different_xy.json"))` not to throw any errors.
+       Actually got a <purrr_error_indexed> with message:
+         i In index: 1.
+         Caused by error in `check_path()`:
+         ! Can't find file at './deployments.csv'.
+       
+       [ FAIL 1 | WARN 6 | SKIP 117 | PASS 12 ]
+       Deleting unused snapshots: 'merge_camtrapdp/datapackage_identical_xy.json',
+       'write_camtrapdp/datapackage.json', 'write_dwc/meta.xml',
+       'write_dwc/multimedia.csv', 'write_dwc/multimedia_media_based.csv',
+       'write_dwc/occurrence.csv', 'write_dwc/occurrence_media_based.csv', and
+       'write_eml/eml.xml'
+       Error:
+       ! Test failures.
+       Execution halted
+     ```
+


### PR DESCRIPTION
Created with:

```
usethis::use_revdep()
revdepcheck::revdep_check(num_workers = 4)
```

This directory (ignore by R build) contains a summary of issues in CRAN packages that rely on frictionless.

(Note: we should do the same for camtrapdp)