### PR TITLE
Generic `version()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # frictionless (development version)
 
+* `version()` is now generic and can report what version of the Data Package standard is used by a Data Package (as before), Data Resource, Table Dialect and Table Schema (#341).
+
 # frictionless 1.3.0
 
 ## Changes for users

--- a/R/version.R
+++ b/R/version.R
@@ -1,22 +1,38 @@
 #' Get Data Package version
 #'
 #' Determines what version of the [Data Package standard](
-#' https://datapackage.org/) is used by a Data Package, based on the
-#' [`$schema`](https://datapackage.org/standard/data-package/#dollar-schema)
-#' property.
+#' https://datapackage.org/) is used by a Data Package, Data Resource, Table
+#' Dialect or Table Schema, based on the [`$schema`](
+#' https://datapackage.org/standard/data-package/#dollar-schema) property.
 #' Version `"1.0"` is assumed if `$schema` is missing, version `">=2.0"` is
 #' assumed for custom values (e.g. [extensions](
 #' https://datapackage.org/standard/extensions/)).
 #'
-#' @inheritParams read_resource
-#' @returns Data Package version number (e.g. `"1.0"`).
+#' @param x A list describing either a:
+#' - Data Package.
+#' - Data Resource.
+#' - Table Dialect.
+#' - Table Schema.
+#' @returns Data Package standard version number (e.g. `"1.0"`).
 #' @family version functions
 #' @export
 #' @examples
+#' # Data Package
 #' package <- example_package()
 #' version(package)
-version <- function(package) {
-  dollar_schema <- purrr::pluck(package, "$schema")
+#'
+#' # Data Resource
+#' resource <- resource(package, "observations")
+#' version(resource)
+#'
+#' # Table Dialect
+#' version(resource$dialect)
+#'
+#' # Table Schema
+#' schema <- schema(package, "observations")
+#' version(schema)
+version <- function(x) {
+  dollar_schema <- purrr::pluck(x, "$schema")
 
   if (is.null(dollar_schema)) {
     return("1.0") # Assume 1.0 if $schema is undefined
@@ -26,7 +42,8 @@ version <- function(package) {
   }
 
   # Extract version from e.g.
-  # "https://datapackage.org/profiles/<version>/datapackage.json"
+  # "https://datapackage.org/profiles/1.0/datapackage.json" or
+  # "https://datapackage.org/profiles/2.0/tableschema.json"
   pattern = "^https://datapackage\\.org/profiles/((?:[0-9A-Za-z]|\\.|-)+)/.*"
   extracted_version <- sub(
     pattern,

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
-#' Get Data Package version
+#' Get Data Package standard version
 #'
 #' Determines what version of the [Data Package standard](
 #' https://datapackage.org/) is used by a Data Package, Data Resource, Table
@@ -8,11 +8,8 @@
 #' assumed for custom values (e.g. [extensions](
 #' https://datapackage.org/standard/extensions/)).
 #'
-#' @param x A list describing either a:
-#' - Data Package.
-#' - Data Resource.
-#' - Table Dialect.
-#' - Table Schema.
+#' @param x A list describing either a Data Package, Data Resource, Table
+#'   Dialect or Table Schema.
 #' @returns Data Package standard version number (e.g. `"1.0"`).
 #' @family version functions
 #' @export

--- a/man/version.Rd
+++ b/man/version.Rd
@@ -2,18 +2,13 @@
 % Please edit documentation in R/version.R
 \name{version}
 \alias{version}
-\title{Get Data Package version}
+\title{Get Data Package standard version}
 \usage{
 version(x)
 }
 \arguments{
-\item{x}{A list describing either a:
-\itemize{
-\item Data Package.
-\item Data Resource.
-\item Table Dialect.
-\item Table Schema.
-}}
+\item{x}{A list describing either a Data Package, Data Resource, Table
+Dialect or Table Schema.}
 }
 \value{
 Data Package standard version number (e.g. \code{"1.0"}).

--- a/man/version.Rd
+++ b/man/version.Rd
@@ -4,24 +4,40 @@
 \alias{version}
 \title{Get Data Package version}
 \usage{
-version(package)
+version(x)
 }
 \arguments{
-\item{package}{Data Package object, as returned by \code{\link[=read_package]{read_package()}} or
-\code{\link[=create_package]{create_package()}}.}
+\item{x}{A list describing either a:
+\itemize{
+\item Data Package.
+\item Data Resource.
+\item Table Dialect.
+\item Table Schema.
+}}
 }
 \value{
-Data Package version number (e.g. \code{"1.0"}).
+Data Package standard version number (e.g. \code{"1.0"}).
 }
 \description{
-Determines what version of the \href{https://datapackage.org/}{Data Package standard} is used by a Data Package, based on the
-\href{https://datapackage.org/standard/data-package/#dollar-schema}{\verb{$schema}}
-property.
+Determines what version of the \href{https://datapackage.org/}{Data Package standard} is used by a Data Package, Data Resource, Table
+Dialect or Table Schema, based on the \href{https://datapackage.org/standard/data-package/#dollar-schema}{\verb{$schema}} property.
 Version \code{"1.0"} is assumed if \verb{$schema} is missing, version \code{">=2.0"} is
 assumed for custom values (e.g. \href{https://datapackage.org/standard/extensions/}{extensions}).
 }
 \examples{
+# Data Package
 package <- example_package()
 version(package)
+
+# Data Resource
+resource <- resource(package, "observations")
+version(resource)
+
+# Table Dialect
+version(resource$dialect)
+
+# Table Schema
+schema <- schema(package, "observations")
+version(schema)
 }
 \concept{version functions}

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -1,44 +1,159 @@
-test_that("version() returns version based on $schema", {
-  p <- create_package()
+test_that("version() returns correct version for Data Package", {
+  package <- create_package()
 
-  # Undefined
-  p$`$schema` <- NULL
-  expect_equal(version(p), "1.0")
+  # Undefined $schema
+  package$`$schema` <- NULL
+  expect_equal(version(package), "1.0")
 
   # Defined default
-  p$`$schema` <- "https://datapackage.org/profiles/1.0/datapackage.json"
-  expect_equal(version(p), "1.0")
+  package$`$schema` <- "https://datapackage.org/profiles/1.0/datapackage.json"
+  expect_equal(version(package), "1.0")
 
   # 2.0
-  p$`$schema` <- "https://datapackage.org/profiles/2.0/datapackage.json"
-  expect_equal(version(p), "2.0")
+  package$`$schema` <- "https://datapackage.org/profiles/2.0/datapackage.json"
+  expect_equal(version(package), "2.0")
 
   # Future versions
-  p$`$schema` <- "https://datapackage.org/profiles/2.1/datapackage.json"
-  expect_equal(version(p), "2.1")
-  p$`$schema` <- "https://datapackage.org/profiles/2.2-rc.1/datapackage.json"
-  expect_equal(version(p), "2.2-rc.1")
-  p$`$schema` <- "https://datapackage.org/profiles/3.0/datapackage.json"
-  expect_equal(version(p), "3.0")
+  package$`$schema` <- "https://datapackage.org/profiles/2.1/datapackage.json"
+  expect_equal(version(package), "2.1")
+  package$`$schema` <- "https://datapackage.org/profiles/2.2-rc.1/datapackage.json"
+  expect_equal(version(package), "2.2-rc.1")
+  package$`$schema` <- "https://datapackage.org/profiles/3.0/datapackage.json"
+  expect_equal(version(package), "3.0")
 
   # Custom extensions
-  p$`$schema` <- "https://spatial.datapackage.org/profiles/1.0/datapackage.json"
-  expect_equal(version(p), ">=2.0")
-  p$`$schema` <- "http://rs.tdwg.org/dwc-dp/1.0/dwc-dp-profile.json"
-  expect_equal(version(p), ">=2.0")
+  package$`$schema` <- "https://custom.datapackage.org/package-profile.json"
+  expect_equal(version(package), ">=2.0")
+  package$`$schema` <- "http://rs.tdwg.org/dwc-dp/1.0/dwc-dp-profile.json"
+  expect_equal(version(package), ">=2.0")
+})
+
+test_that("version() returns correct version for Data Resource", {
+  resource <- list(
+    name = "custom_resource",
+    path = "https://example.com/data.csv"
+  )
+
+  # Undefined $schema
+  resource$`$schema` <- NULL
+  expect_equal(version(resource), "1.0")
+
+  # Defined default
+  resource$`$schema` <- "https://datapackage.org/profiles/1.0/dataresource.json"
+  expect_equal(version(resource), "1.0")
+
+  # 2.0
+  resource$`$schema` <- "https://datapackage.org/profiles/2.0/dataresource.json"
+  expect_equal(version(resource), "2.0")
+
+  # Future versions
+  resource$`$schema` <- "https://datapackage.org/profiles/2.1/dataresource.json"
+  expect_equal(version(resource), "2.1")
+  resource$`$schema` <- "https://datapackage.org/profiles/2.2-rc.1/dataresource.json"
+  expect_equal(version(resource), "2.2-rc.1")
+  resource$`$schema` <- "https://datapackage.org/profiles/3.0/dataresource.json"
+  expect_equal(version(resource), "3.0")
+
+  # Custom extensions
+  resource$`$schema` <- "https://custom.datapackage.org/resource-profile.json"
+  expect_equal(version(resource), ">=2.0")
+})
+
+test_that("version() returns correct version for Table Dialect", {
+  # Entire dialect undefined => $schema is undefined => 1.0
+  dialect <- NULL
+  expect_equal(version(dialect), "1.0")
+
+  # Undefined $schema
+  dialect <- list(
+    delimiter = ","
+  )
+  dialect$`$schema` <- NULL
+  expect_equal(version(dialect), "1.0")
+
+  # Defined default
+  dialect$`$schema` <- "https://datapackage.org/profiles/1.0/tabledialect.json"
+  expect_equal(version(dialect), "1.0")
+
+  # 2.0
+  dialect$`$schema` <- "https://datapackage.org/profiles/2.0/tabledialect.json"
+  expect_equal(version(dialect), "2.0")
+
+  # Future versions
+  dialect$`$schema` <- "https://datapackage.org/profiles/2.1/tabledialect.json"
+  expect_equal(version(dialect), "2.1")
+  dialect$`$schema` <- "https://datapackage.org/profiles/2.2-rc.1/tabledialect.json"
+  expect_equal(version(dialect), "2.2-rc.1")
+  dialect$`$schema` <- "https://datapackage.org/profiles/3.0/tabledialect.json"
+  expect_equal(version(dialect), "3.0")
+
+  # Custom extensions
+  dialect$`$schema` <- "https://custom.datapackage.org/dialect-profile.json"
+  expect_equal(version(dialect), ">=2.0")
+})
+
+test_that("version() returns correct version for Table Schema", {
+  schema <- list(
+    fields = list()
+  )
+
+  # Undefined $schema
+  schema$`$schema` <- NULL
+  expect_equal(version(schema), "1.0")
+
+  # Defined default
+  schema$`$schema` <- "https://datapackage.org/profiles/1.0/tableschema.json"
+  expect_equal(version(schema), "1.0")
+
+  # 2.0
+  schema$`$schema` <- "https://datapackage.org/profiles/2.0/tableschema.json"
+  expect_equal(version(schema), "2.0")
+
+  # Future versions
+  schema$`$schema` <- "https://datapackage.org/profiles/2.1/tableschema.json"
+  expect_equal(version(schema), "2.1")
+  schema$`$schema` <- "https://datapackage.org/profiles/2.2-rc.1/tableschema.json"
+  expect_equal(version(schema), "2.2-rc.1")
+  schema$`$schema` <- "https://datapackage.org/profiles/3.0/tableschema.json"
+  expect_equal(version(schema), "3.0")
+
+  # Custom extensions
+  schema$`$schema` <- "https://custom.datapackage.org/schema-profile.json"
+  expect_equal(version(schema), ">=2.0")
 })
 
 test_that("version() returns >=2.0 for invalid $schema", {
-  p <- create_package()
-  p$`$schema` <- list()
-  expect_equal(version(p), ">=2.0")
-  p$`$schema` <- 3.0
-  expect_equal(version(p), ">=2.0")
+  x <- list()
+  x$`$schema` <- list()
+  expect_equal(version(x), ">=2.0")
+  x$`$schema` <- 3.0
+  expect_equal(version(x), ">=2.0")
 })
 
-test_that("version() returns correct version for example packages", {
+test_that("version() returns correct version for example package properties", {
   p_1.0 <- example_package(version = "1.0")
+
+  # Data Package
   expect_equal(version(p_1.0), "1.0")
-  p_2.0 <- suppressWarnings(example_package(version = "2.0"))
+  # Data Resource
+  expect_equal(version(p_1.0$resources[[1]]), "1.0")
+  # Data Dialect (undefined for deployments)
+  expect_equal(version(p_1.0$resources[[1]]$dialect), "1.0")
+  # Table Dialect (defined for observations)
+  expect_equal(version(p_1.0$resources[[2]]$dialect), "1.0")
+  # Table Schema
+  expect_equal(version(p_1.0$resources[[1]]$schema), "1.0")
+
+  p_2.0 <- example_package(version = "2.0")
+
+  # Data Package
   expect_equal(version(p_2.0), "2.0")
+  # Data Resource
+  expect_equal(version(p_2.0$resources[[1]]), "2.0")
+  # Data Dialect (undefined for deployments)
+  expect_equal(version(p_2.0$resources[[1]]$dialect), "1.0")
+  # Table Dialect (defined for observations)
+  expect_equal(version(p_2.0$resources[[2]]$dialect), "2.0")
+  # Table Schema
+  expect_equal(version(p_2.0$resources[[1]]$schema), "2.0")
 })


### PR DESCRIPTION
Fix #340 

No changes to the function were needed, since the version is always detected with the presence and value of `$schema`, which is a property of:
- Data Package
- Data Resource
- Table Dialect
- Table Schema

So this is mainly a change in documentation + an expansion of the tests.

Note that in the last test I don't make use of the convenience functions `resource()` and `schema()` since those functions will automatically upgrade to 2.0 in the future.